### PR TITLE
Add filename param to main interface

### DIFF
--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -42,11 +42,12 @@ class ASTTokens(object):
   If only ``source_text`` is given, you may use ``.mark_tokens(tree)`` to mark the nodes of an AST
   tree created separately.
   """
-  def __init__(self, source_text, parse=False, tree=None):
+  def __init__(self, source_text, parse=False, tree=None, filename='<unknown>'):
     if isinstance(source_text, six.binary_type):
       source_text = source_text.decode('utf8')
 
-    self._tree = ast.parse(source_text) if parse else tree
+    self._filename = filename
+    self._tree = ast.parse(source_text, filename) if parse else tree
 
     self._text = source_text
     self._line_numbers = LineNumbers(source_text)
@@ -98,6 +99,11 @@ class ASTTokens(object):
   def tree(self):
     """The root of the AST tree passed into the constructor or parsed from the source code."""
     return self._tree
+
+  @property
+  def filename(self):
+    """The filename that was parsed"""
+    return self._filename
 
   def get_token_from_offset(self, offset):
     """


### PR DESCRIPTION
This PR adds the parameter `filename` to the main ASTToken interface.

I took some liberty making some decisions that may have undesired consequences:

~1) I made `filename` a param after `source_text` to better mimic `ast.parse`'s interface - this will cause issues if someone used this library without kwargs. If this was python3 I would've added `*` between `filename` and `parse` to enforce this going forward~
2) I duplicated `filename` on the instance since the tree can be passed independently (see line 50)
3) I added a getter because why not

Fixes #8 