### PR TITLE
Handle JoinedStr nodes (f-strings in Python 3)

### DIFF
--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -230,6 +230,12 @@ class MarkTokens(object):
     return (first_token, last_token)
 
   def visit_str(self, node, first_token, last_token):
+    return self.handle_str(first_token, last_token)
+
+  def visit_joinedstr(self, node, first_token, last_token):
+    return self.handle_str(first_token, last_token)
+
+  def handle_str(self, first_token, last_token):
     # Multiple adjacent STRING tokens form a single string.
     last = self._code.next_token(last_token)
     while util.match_token(last, token.STRING):

--- a/tests/test_asttokens.py
+++ b/tests/test_asttokens.py
@@ -81,7 +81,7 @@ class TestASTTokens(unittest.TestCase):
 
 
   def test_to_source(self):
-    # Verify that to_source() actually works, with a coulpe of cases that have caused hiccups.
+    # Verify that to_source() actually works, with a couple of cases that have caused hiccups.
     source = "foo(a, b, *d, c=2, **e)"
     root = ast.parse(source)
     self.assertEqual(tools.to_source(root.body[0]), source)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -225,6 +225,27 @@ bar = ('x y z'   # comment2
       node_name + ":'x y z'   # comment2\n       'a b c'   # comment3\n       'u v w'"
     })
 
+  def test_adjacent_joined_strings(self):
+    if sys.version_info < (3, 6):
+      # This test only makes sense in Python 3.6 and later
+      return
+
+    source = """
+foo = f'x y z' \\
+f'''a b c''' f"u v w"
+bar = ('x y z'   # comment2
+       'a b c'   # comment3
+       f'u v w'
+      )
+"""
+    m = self.create_mark_checker(source)
+    self.assertEqual(m.view_nodes_at(2, 6), {
+      "JoinedStr:f'x y z' \\\nf'''a b c''' f\"u v w\""
+    })
+    self.assertEqual(m.view_nodes_at(4, 7), {
+      "JoinedStr:'x y z'   # comment2\n       'a b c'   # comment3\n       f'u v w'"
+    })
+
 
   def test_print_function(self):
     # This testcase imports print as function (using from __future__). Check that we can parse it.

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -225,27 +225,6 @@ bar = ('x y z'   # comment2
       node_name + ":'x y z'   # comment2\n       'a b c'   # comment3\n       'u v w'"
     })
 
-  def test_adjacent_joined_strings(self):
-    if sys.version_info < (3, 6):
-      # This test only makes sense in Python 3.6 and later
-      return
-
-    source = """
-foo = f'x y z' \\
-f'''a b c''' f"u v w"
-bar = ('x y z'   # comment2
-       'a b c'   # comment3
-       f'u v w'
-      )
-"""
-    m = self.create_mark_checker(source)
-    self.assertEqual(m.view_nodes_at(2, 6), {
-      "JoinedStr:f'x y z' \\\nf'''a b c''' f\"u v w\""
-    })
-    self.assertEqual(m.view_nodes_at(4, 7), {
-      "JoinedStr:'x y z'   # comment2\n       'a b c'   # comment3\n       f'u v w'"
-    })
-
 
   def test_print_function(self):
     # This testcase imports print as function (using from __future__). Check that we can parse it.
@@ -296,6 +275,23 @@ bar = ('x y z'   # comment2
         "def t():\n  return f'{function(kwarg=24)}'"):
         m = self.create_mark_checker(source)
         m.verify_all_nodes(self)
+
+    def test_adjacent_joined_strings(self):
+        source = """
+foo = f'x y z' \\
+f'''a b c''' f"u v w"
+bar = ('x y z'   # comment2
+       'a b c'   # comment3
+       f'u v w'
+      )
+"""
+        m = self.create_mark_checker(source)
+        self.assertEqual(m.view_nodes_at(2, 6), {
+            "JoinedStr:f'x y z' \\\nf'''a b c''' f\"u v w\""
+        })
+        self.assertEqual(m.view_nodes_at(4, 7), {
+            "JoinedStr:'x y z'   # comment2\n       'a b c'   # comment3\n       f'u v w'"
+        })
 
 
   def test_splat(self):


### PR DESCRIPTION
This diff adds special handling for `JoinedStr` nodes (which are produced by f-strings added in Python 3.6). This handling mirrors what is already being done for normal strings. Before, the `source` attribute of a `JoinedStr` node would only have the first token if the string used compile-time concatenation; now it will have all the tokens in that case.

I added a test that mirrors the existing `Str` test, saw that it failed, implemented the fix, and saw that it now succeeds. I ran the test on Python 2.7 and 3.6 and saw that it passed on both. I temporarily took out the guard at the beginning of the test and ran in on Python 2 and saw that it failed with a syntax error.