### PR TITLE
Adjust With nodes to include the "with " text

### DIFF
--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import six
+import sys
 import numbers
 import token
 from . import util
@@ -278,4 +279,12 @@ class MarkTokens(object):
     if util.match_token(first_token, token.NAME, 'except'):
       colon = self._code.find_token(last_token, token.OP, ':')
       first_token = last_token = self._code.prev_token(colon)
+    return (first_token, last_token)
+
+  def visit_with(self, node, first_token, last_token):
+    if sys.version_info < (3, 0):
+      # Apparently in Python 2 the `col_offset` returned by the ast module on With nodes starts
+      # after the `with ` text. This adjusts it so that that text is also included as part of the
+      # node.
+      first_token = self._code.prev_token(first_token)
     return (first_token, last_token)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -448,3 +448,12 @@ bar = ('x y z'   # comment2
     else:
       self.assertEqual(m.view_nodes_at(5, 0), {'FunctionDef:@deco2(a=1)\ndef g(x):\n  pass'})
     self.assertEqual(m.view_nodes_at(5, 1), {'Name:deco2', 'Call:deco2(a=1)'})
+
+  def test_with(self):
+    source = "with foo: pass"
+    m = self.create_mark_checker(source)
+    self.assertEqual(m.view_node_types_at(1, 0), {"Module", "With"})
+    self.assertEqual(m.view_nodes_at(1, 0), {
+      "Module:with foo: pass",
+      "With:with foo: pass",
+    })


### PR DESCRIPTION
Apparently in Python 2 the `col_offset` of `With` nodes starts after the "with " text. This behavior is confusing and inconsistent with Python 3, which has the offset start at the beginning of the "with".

For an example of the issue, run the following commands:

```
$ python3 -c 'import ast; print(ast.parse("with foo: pass").body[0].col_offset)'
0
$ python -c 'import ast; print(ast.parse("with foo: pass").body[0].col_offset)'
5
```

This diff adds a test that the `With` node includes the "with" text, and corresponding behavior to fix up the start location when running under Python 3.