### PR TITLE
Adjust With nodes to include the "with" text.

### DIFF
--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import six
-import sys
 import numbers
 import token
 from . import util

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import six
+import sys
 import numbers
 import token
 from . import util
@@ -278,4 +279,12 @@ class MarkTokens(object):
     if util.match_token(first_token, token.NAME, 'except'):
       colon = self._code.find_token(last_token, token.OP, ':')
       first_token = last_token = self._code.prev_token(colon)
+    return (first_token, last_token)
+
+  def visit_with(self, node, first_token, last_token):
+    if sys.version_info < (3, 0):
+      # Apparently in Python 2 the `col_offset` returned by the ast module on With nodes starts
+      # after the `with ` text. This adjusts it so that that text is also included as part of the
+      # node.
+      first_token = self._code.prev_token(first_token)
     return (first_token, last_token)

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -281,10 +281,8 @@ class MarkTokens(object):
       first_token = last_token = self._code.prev_token(colon)
     return (first_token, last_token)
 
-  def visit_with(self, node, first_token, last_token):
-    if sys.version_info < (3, 0):
-      # Apparently in Python 2 the `col_offset` returned by the ast module on With nodes starts
-      # after the `with ` text. This adjusts it so that that text is also included as part of the
-      # node.
-      first_token = self._code.prev_token(first_token)
-    return (first_token, last_token)
+  if six.PY2:
+    # No need for this on Python3, which already handles 'with' nodes correctly.
+    def visit_with(self, node, first_token, last_token):
+      first = self._code.find_token(first_token, token.NAME, 'with', reverse=True)
+      return (first, last_token)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -457,3 +457,27 @@ bar = ('x y z'   # comment2
       "Module:with foo: pass",
       "With:with foo: pass",
     })
+
+    source = textwrap.dedent(
+      '''
+      def f(x):
+        with A() as a:
+          log(a)
+          with B() as b, C() as c: log(b, c)
+        log(x)
+      ''')
+    m = self.create_mark_checker(source)
+    self.assertEqual(m.view_nodes_at(5, 4), {
+      'With:with B() as b, C() as c: log(b, c)'
+    })
+    self.assertEqual(m.view_nodes_at(3, 2), {
+      'With:  with A() as a:\n    log(a)\n    with B() as b, C() as c: log(b, c)'
+    })
+    with_nodes = [n for n in m.all_nodes if n.__class__.__name__ == 'With']
+    self.assertEqual({m.view_node(n) for n in with_nodes}, {
+      'With:with B() as b, C() as c: log(b, c)',
+      'With:  with A() as a:\n    log(a)\n    with B() as b, C() as c: log(b, c)',
+    })
+    if not six.PY2:
+      # This verification fails on Python2 which turns `with X, Y` turns into `with X: with Y`.
+      m.verify_all_nodes(self)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -448,3 +448,12 @@ bar = ('x y z'   # comment2
     else:
       self.assertEqual(m.view_nodes_at(5, 0), {'FunctionDef:@deco2(a=1)\ndef g(x):\n  pass'})
     self.assertEqual(m.view_nodes_at(5, 1), {'Name:deco2', 'Call:deco2(a=1)'})
+
+  def test_with(self):
+    source = "with foo: pass"
+    m = self.create_mark_checker(source)
+    self.assertEqual(m.view_node_types_at(1, 0), {"Module", "With"})
+    self.assertEqual(m.view_nodes_at(1, 0), {
+      "Module:with foo: pass",
+      "With:with foo: pass",
+    })


### PR DESCRIPTION
Apparently in Python 2 the `col_offset` of `With` nodes starts after the "with " text, which is incorrect. It works correctly on Python 3. This PR fixes it for Python 2.

Builds on PR #14 by @FuegoFro, with a different implementation and more testing.
 