### PR TITLE
Fixes to make asttokens work with Python3.7 and astroid 2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+sudo: false
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 # command to install dependencies
 install: pip install tox-travis
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: pip install tox-travis
 # command to run tests
-script: nosetests
+script: tox

--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -20,7 +20,7 @@ import io
 import six
 from six.moves import xrange      # pylint: disable=redefined-builtin
 from .line_numbers import LineNumbers
-from .util import Token, match_token
+from .util import Token, match_token, is_non_coding_token
 from .mark_tokens import MarkTokens
 
 class ASTTokens(object):
@@ -135,7 +135,7 @@ class ASTTokens(object):
     """
     i = tok.index + 1
     if not include_extra:
-      while self._tokens[i].type >= token.N_TOKENS:
+      while is_non_coding_token(self._tokens[i].type):
         i += 1
     return self._tokens[i]
 
@@ -146,7 +146,7 @@ class ASTTokens(object):
     """
     i = tok.index - 1
     if not include_extra:
-      while self._tokens[i].type >= token.N_TOKENS:
+      while is_non_coding_token(self._tokens[i].type):
         i -= 1
     return self._tokens[i]
 
@@ -168,7 +168,7 @@ class ASTTokens(object):
     include_extra is True, includes non-coding tokens such as tokenize.NL and .COMMENT.
     """
     for i in xrange(first_token.index, last_token.index + 1):
-      if include_extra or self._tokens[i].type < token.N_TOKENS:
+      if include_extra or not is_non_coding_token(self._tokens[i].type):
         yield self._tokens[i]
 
   def get_tokens(self, node, include_extra=False):

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -57,6 +57,20 @@ def expect_token(token, tok_type, tok_str=None):
       token_repr(tok_type, tok_str), str(token),
       token.start[0], token.start[1] + 1))
 
+# These were previously defined in tokenize.py and distinguishable by being greater than
+# token.N_TOKEN. As of python3.7, they are in token.py, and we check for them explicitly.
+if hasattr(token, 'COMMENT'):
+  def is_non_coding_token(token_type):
+    """
+    These are considered non-coding tokens, as they don't affect the syntax tree.
+    """
+    return token_type in (token.NL, token.COMMENT, token.ENCODING)
+else:
+  def is_non_coding_token(token_type):
+    """
+    These are considered non-coding tokens, as they don't affect the syntax tree.
+    """
+    return token_type >= token.N_TOKENS
 
 def iter_children(node):
   """

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py{27,35,36,37}
 
 [testenv]
 commands = nosetests
 deps =
     nose
-    astroid
     coverage
+    py{27,35,36}: astroid
+    py{37}: astroid>=2.dev


### PR DESCRIPTION
Fixes detection of non-coding tokens to work with py37.
Skips testing of deep-recursion on astroid 2.0, which no longer supports it.
Adds Python3.7 testing to tox.ini.

Fixes #16 .