### PR TITLE
Per issue #21, delay decoding the source code until _after_ parsing.

### DIFF
--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -43,11 +43,14 @@ class ASTTokens(object):
   tree created separately.
   """
   def __init__(self, source_text, parse=False, tree=None, filename='<unknown>'):
-    if isinstance(source_text, six.binary_type):
-      source_text = source_text.decode('utf8')
-
     self._filename = filename
     self._tree = ast.parse(source_text, filename) if parse else tree
+
+    # Decode source after parsing to let Python 2 handle coding declarations.
+    # (If the encoding was not utf-8 compatible, then even if it parses correctly,
+    # we'll fail with a unicode error here.)
+    if isinstance(source_text, six.binary_type):
+      source_text = source_text.decode('utf8')
 
     self._text = source_text
     self._line_numbers = LineNumbers(source_text)

--- a/tests/test_asttokens.py
+++ b/tests/test_asttokens.py
@@ -135,6 +135,11 @@ class TestASTTokens(unittest.TestCase):
     self.assertEqual(atok.get_text(a_node), "a")
     self.assertEqual(atok.get_text(b_node), "b")
 
+  def test_coding_declaration(self):
+    """ASTTokens should be able to parse a string with a coding declaration."""
+    # In Python 2, a unicode string with a coding declaration is a SyntaxError.
+    # So, if we aren't careful, this will raise a SyntaxError in Python 2:
+    asttokens.ASTTokens(str("# coding: ascii\n1"), parse=True)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Because Python 2 forbids coding declarations inside of unicode strings, passing unicode/text strings to ast.parse makes all files with coding declarations unparseable with asttokens in Python 2.