### PR TITLE
tests: use Constant for Num, Str, NameConstant node names

### DIFF
--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -181,11 +181,11 @@ b +     # line3
       m = self.create_mark_checker(source)
       self.assertEqual(len(m.all_nodes), 2104)
       self.assertEqual(m.view_node(m.all_nodes[-1]),
-                       "Str:'F1akOFFiRIgPHTZksKBAgMCLGTdGNIAAQgKfDAcgZbj0odOnUA8GBAA7'")
+                       "Constant:'F1akOFFiRIgPHTZksKBAgMCLGTdGNIAAQgKfDAcgZbj0odOnUA8GBAA7'")
       self.assertEqual(m.view_node(m.all_nodes[-2]),
-                       "Str:'Ii0uLDAxLzI0Mh44U0gxMDI5JkM0JjU3NDY6Kjc5Njo7OUE8Ozw+Oz89QTxA'")
+                       "Constant:'Ii0uLDAxLzI0Mh44U0gxMDI5JkM0JjU3NDY6Kjc5Njo7OUE8Ozw+Oz89QTxA'")
       self.assertEqual(m.view_node(m.all_nodes[1053]),
-                       "Str:'R0lGODlhigJnAef/AAABAAEEAAkCAAMGAg0GBAYJBQoMCBMODQ4QDRITEBkS'")
+                       "Constant:'R0lGODlhigJnAef/AAABAAEEAAkCAAMGAg0GBAYJBQoMCBMODQ4QDRITEBkS'")
       self.assertEqual(m.view_node(m.all_nodes[1052]),
                        "BinOp:'R0lGODlhigJnAef/AAABAAEEAAkCAAMGAg0GBAYJBQoMCBMODQ4QDRITEBkS'\r\n" +
                        "     +'CxsSEhkWDhYYFQ0aJhkaGBweGyccGh8hHiIkIiMmGTEiHhQoPSYoJSkqKDcp'")
@@ -225,7 +225,7 @@ bar = ('x y z'   # comment2
       )
 """
     m = self.create_mark_checker(source)
-    node_name = 'Const' if self.is_astroid_test else 'Str'
+    node_name = 'Const' if self.is_astroid_test else 'Constant'
     self.assertEqual(m.view_nodes_at(2, 6), {
       node_name + ":'x y z' \\\n'''a b c''' \"u v w\""
     })
@@ -336,7 +336,7 @@ bar = ('x y z'   # comment2
     name_a = 'AssignName:a' if self.is_astroid_test else 'Name:a'
     const_true = ('Const:True' if self.is_astroid_test else
                   'Name:True' if six.PY2 else
-                  'NameConstant:True')
+                  'Constant:True')
     self.assertEqual(m.view_nodes_at(1, 0),
                      {name_a, "Assign:a = True if True else False", "Module:" + source})
     self.assertEqual(m.view_nodes_at(1, 4),
@@ -388,7 +388,7 @@ bar = ('x y z'   # comment2
     if self.is_astroid_test:
       self.assertEqual(m.view_nodes_at(1, 5), {'Const:4'})
     else:
-      self.assertEqual(m.view_nodes_at(1, 5), {'Num:4'})
+      self.assertEqual(m.view_nodes_at(1, 5), {'Constant:4'})
     self.assertEqual(m.view_nodes_at(2, 0), {'Delete:del x[4]'})
     self.assertEqual(m.view_nodes_at(2, 4), {'Name:x', 'Subscript:x[4]'})
 
@@ -428,7 +428,7 @@ bar = ('x y z'   # comment2
       self.assertEqual(m.view_nodes_at(2, 8), {'Keyword:b=[y]'})
     else:
       self.assertEqual(m.view_nodes_at(1, 2), {'keyword:x=1'})
-      self.assertEqual(m.view_nodes_at(1, 4), {'Num:1'})
+      self.assertEqual(m.view_nodes_at(1, 4), {'Constant:1'})
       self.assertEqual(m.view_nodes_at(2, 2), {'keyword:a=(x)'})
       self.assertEqual(m.view_nodes_at(2, 8), {'keyword:b=[y]'})
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ import ast
 import astroid
 import unittest
 from .context import asttokens
+from .tools import get_node_name
 
 class TestUtil(unittest.TestCase):
 
@@ -37,7 +38,7 @@ class TestUtil(unittest.TestCase):
     atok = asttokens.ASTTokens(self.source, parse=True)
 
     def view(node):
-      return "%s:%s" % (node.__class__.__name__, atok.get_text(node))
+      return "%s:%s" % (get_node_name(node), atok.get_text(node))
 
     scan = [view(n) for n in asttokens.util.walk(atok.tree)]
     self.assertEqual(scan, [
@@ -48,20 +49,20 @@ class TestUtil(unittest.TestCase):
       'Call:bar(1 + 2)',
       'Name:bar',
       'BinOp:1 + 2',
-      'Num:1',
-      'Num:2',
+      'Constant:1',
+      'Constant:2',
       "BinOp:'hello' + ', ' + 'world'",
       "BinOp:'hello' + ', '",
-      "Str:'hello'",
-      "Str:', '",
-      "Str:'world'"
+      "Constant:'hello'",
+      "Constant:', '",
+      "Constant:'world'"
     ])
 
   def test_walk_astroid(self):
     atok = asttokens.ASTTokens(self.source, tree=astroid.builder.parse(self.source))
 
     def view(node):
-      return "%s:%s" % (node.__class__.__name__, atok.get_text(node))
+      return "%s:%s" % (get_node_name(node), atok.get_text(node))
 
     scan = [view(n) for n in asttokens.util.walk(atok.tree)]
     self.assertEqual(scan, [

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -96,6 +96,10 @@ def collect_nodes_preorder(root):
   util.visit_tree(root, append, None)
   return nodes
 
+def get_node_name(node):
+   name = node.__class__.__name__
+   return 'Constant' if name in ('Num', 'Str', 'NameConstant') else name
+
 
 class MarkChecker(object):
   """
@@ -112,7 +116,7 @@ class MarkChecker(object):
 
   def view_node(self, node):
     """Returns a representation of a node and its text, such as "Call:foo()". """
-    return "%s:%s" % (node.__class__.__name__, self.atok.get_text(node))
+    return "%s:%s" % (get_node_name(node), self.atok.get_text(node))
 
   def view_nodes_at(self, line, col):
     """


### PR DESCRIPTION
This fixes some test failures under python3.8. All tests still pass on
python3.7. Partially addresses #28, replaces #29.
As suggested in https://github.com/gristlabs/asttokens/pull/29/files#r280123329.