### PR TITLE
Iterate over dict AST children in source order.

### DIFF
--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -103,6 +103,14 @@ def iter_children_ast(node):
   if is_joined_str(node):
     return
 
+  if isinstance(node, ast.Dict):
+    # override the iteration order: instead of <all keys>, <all values>,
+    # yield keys and values in source order (key1, value1, key2, value2, ...)
+    for (key, value) in zip(node.keys, node.values):
+      yield key
+      yield value
+    return
+
   for child in ast.iter_child_nodes(node):
     # Skip singleton children; they don't reflect particular positions in the code and break the
     # assumptions about the tree consisting of distinct nodes. Note that collecting classes

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -379,6 +379,13 @@ bar = ('x y z'   # comment2
       m = self.create_mark_checker(source)
       m.verify_all_nodes(self)
 
+  def test_dict_order(self):
+    # Make sure we iterate over dict keys/values in source order.
+    # See https://github.com/gristlabs/asttokens/issues/31
+    source = 'f({1: (2), 3: 4}, object())'
+    m = self.create_mark_checker(source)
+    m.verify_all_nodes(self)
+
   def test_del_dict(self):
     # See https://bitbucket.org/plas/thonny/issues/24/try-del-from-dictionary-in-debugging-mode
     source = "x = {4:5}\ndel x[4]"


### PR DESCRIPTION
This should fix issue #31, and the added test case is a copy of that issue's test.

asttokens is iterating in the order given by ast.iter_child_nodes, which goes field by field and iterates over all members of that field. This means that all keys get yielded, before all values, instead of yielding them in source order. My guess is that this messes up the parenthesis tracking, because it sees `1`, and then `:(2),` between consecutive nodes, and then `3`. That's the keys. Then for values, it sees `2`, `), 3: ` between nodes, and then `4`. So it thinks that it's seen a closing parenthesis between the 2 and the 3 because it counted that span twice.

By iterating over the children in actual source order, the double counting of the `)` is removed.

I haven't verified by actually understanding the code, this was just a guess on a lark, because I remembered that the dict child order was annoying (and it broke my own refactoring tool based on asttokens at one point).