### PR TITLE
Remove _iter_non_child_tokens and just use all tokens to find matching pairs

### DIFF
--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -103,22 +103,6 @@ class MarkTokens(object):
       newline = self._code.find_token(start_token, token.ENDMARKER)
     return self._code.prev_token(newline)
 
-  def _iter_non_child_tokens(self, first_token, last_token, node):
-    """
-    Generates all tokens in [first_token, last_token] range that do not belong to any children of
-    node. E.g. `foo(bar)` has children `foo` and `bar`, but we would yield the `(`.
-    """
-    tok = first_token
-    for n in self._iter_children(node):
-      for t in self._code.token_range(tok, self._code.prev_token(n.first_token)):
-        yield t
-      if n.last_token.index >= last_token.index:
-        return
-      tok = self._code.next_token(n.last_token)
-
-    for t in self._code.token_range(tok, last_token):
-      yield t
-
   def _expand_to_matching_pairs(self, first_token, last_token, node):
     """
     Scan tokens in [first_token, last_token] range that are between node's children, and for any
@@ -128,7 +112,7 @@ class MarkTokens(object):
     # child nodes). If we find any closing ones, we match them to the opens.
     to_match_right = []
     to_match_left = []
-    for tok in self._iter_non_child_tokens(first_token, last_token, node):
+    for tok in self._code.token_range(first_token, last_token):
       tok_info = tok[:2]
       if to_match_right and tok_info == to_match_right[-1]:
         to_match_right.pop()

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -520,3 +520,8 @@ bar = ('x y z'   # comment2
                      {"Call:(obj.attribute.get_callback() or default_callback)()"})
     self.assertIn('BoolOp:obj.attribute.get_callback() or default_callback', m.view_nodes_at(8, 5))
     m.verify_all_nodes(self)
+
+  def test_complex_slice_and_parens(self):
+    source = 'f((x)[:, 0])'
+    m = self.create_mark_checker(source)
+    m.verify_all_nodes(self)


### PR DESCRIPTION
Fixes #35 

In that case `_iter_non_child_tokens` was only yielding the first `(` and nothing else, even though it had the full range of tokens to look through. Overall it seems like rather complex logic so I'm not surprised it was a little flaky. I also don't know what the value was, was it to improve performance when finding matching pairs?