### PR TITLE
Coveralls, pytest, and faster astroid tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - pip install .[test]
 
 script:
-  - coverage run --include='asttokens/*' -m pytest --disable-warnings tests/*.py
+  - coverage run --include='asttokens/*' -m pytest
   - coverage report -m
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
+dist: xenial
 language: python
 sudo: false
 
-matrix:
-  include:
-    - python: 2.7
-    - python: 3.5
-    - python: 3.6
-    - python: 3.7
-    - python: 3.8-dev
-    - python: pypy2.7-6.0
-    - python: pypy3.5
-      dist: xenial
-      sudo: true
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8-dev
+  - pypy2.7-6.0
+  - pypy3.5
 
-# command to install dependencies
-install: pip install tox-travis
-# command to run tests
-script: tox
+install:
+  - pip install coveralls
+  - pip install .[test]
+
+script:
+  - coverage run --include='asttokens/*' -m pytest --disable-warnings tests/*.py
+  - coverage report -m
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - pip install .[test]
 
 script:
-  - coverage run --include='asttokens/*' -m pytest
+  - travis_wait 30 coverage run --include='asttokens/*' -m pytest
   - coverage report -m
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ python:
   - pypy2.7-6.0
   - pypy3.5
 
+env:
+  - ASTTOKENS_SLOW_TESTS=1
+
 install:
   - pip install coveralls
   - pip install .[test]

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,16 @@ the code (or a particular AST node), which is more useful and powerful than deal
 directly.
 
 
-Tests
------
-Tests are in the ``tests/`` subdirectory. To run all tests, run::
+Contribute
+----------
 
-    nosetests
+To contribute:
+
+1. Fork this repository, and clone your fork.
+2. Install the package with test dependencies (ideally in a virtualenv) with::
+
+    pip install -e '.[test]'
+
+3. Run tests in your current interpreter with the command ``pytest`` or ``python -m pytest``.
+4. Run tests across all supported interpreters with the ``tox`` command. You will need to have the interpreters installed separately. We recommend ``pyenv`` for that. Use ``tox -p auto`` to run the tests in parallel.
+5. By default certain tests which take a very long time to run are skipped, but they are run on travis CI. To run them locally, set the environment variable ``ASTTOKENS_SLOW_TESTS``. For example run ``ASTTOKENS_SLOW_TESTS=1 tox`` to run the full suite of tests.

--- a/requirements-top.txt
+++ b/requirements-top.txt
@@ -1,4 +1,0 @@
-astroid
-coverage
-nose
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-astroid==1.5.3
-coverage==4.2
-lazy-object-proxy==1.3.1
-nose==1.3.7
-six==1.10.0
-wrapt==1.10.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ universal=1
 
 [metadata]
 license_file = LICENSE
+
+[tool:pytest]
+addopts = --disable-warnings --ignore=tests/testdata

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ setup(
   # for example:
   # $ pip install -e .[dev,test]
   extras_require={
-    'test': ['astroid', 'nose', 'coverage'],
+    'test': ['astroid', 'pytest'],
   },
-  test_suite="nose.collector",
 )

--- a/tests/test_astroid.py
+++ b/tests/test_astroid.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, print_function
 import re
 
 import astroid
+
 from . import tools, test_mark_tokens
 
 
@@ -12,38 +13,27 @@ class TestAstroid(test_mark_tokens.TestMarkTokens):
   is_astroid_test = True
   module = astroid
 
+  nodes_classes = astroid.ALL_NODE_CLASSES
+  context_classes = [
+    (astroid.Name, astroid.DelName, astroid.AssignName),
+    (astroid.Attribute, astroid.DelAttr, astroid.AssignAttr),
+  ]
+
+  @staticmethod
+  def iter_fields(node):
+    """
+    Yield a tuple of ``(fieldname, value)`` for each field
+    that is present on *node*.
+
+    Similar to ast.iter_fields, but for astroid and ignores context
+    """
+    for field in node._astroid_fields + node._other_fields:
+      if field == 'ctx':
+        continue
+      yield field, getattr(node, field)
+
   @classmethod
   def create_mark_checker(cls, source):
     builder = astroid.builder.AstroidBuilder()
     tree = builder.string_build(source)
     return tools.MarkChecker(source, tree=tree)
-
-  def assert_nodes_equal(self, node1, node2):
-    self.assertEqual(
-      repr_tree(node1),
-      repr_tree(node2),
-    )
-
-
-def repr_tree(node):
-  """
-  Returns a canonical string representation of an astroid node
-  normalised to ignore the context of each node which can change when parsing
-  substrings of source code.
-
-  E.g. "a" is a Name in expression "a + 1" and is an AssignName in expression "a = 1",
-  but we don't care about this difference when comparing structure and content.
-  """
-  result = node.repr_tree()
-
-  # astroid represents context in multiple ways
-  # Convert Store and Del contexts to Load
-  # Similarly convert Assign/Del Name/Attr to just Name/Attribute (i.e. Load)
-  result = re.sub(r'(AssignName|DelName)(\(\s*name=)', r'Name\2', result)
-  result = re.sub(r'(AssignAttr|DelAttr)(\(\s*attrname=)', r'Attribute\2', result)
-  result = re.sub(r'ctx=<Context\.(Store: 2|Del: 3)>', r'ctx=<Context.Load: 1>', result)
-
-  # Weird bug in astroid that collapses spaces in docstrings sometimes maybe
-  result = re.sub(r"' +\\n'", r"'\\n'", result)
-
-  return result

--- a/tests/test_astroid.py
+++ b/tests/test_astroid.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function
 
-import re
-
 import astroid
+from astroid.node_classes import NodeNG
 
 from . import tools, test_mark_tokens
 
@@ -13,7 +12,7 @@ class TestAstroid(test_mark_tokens.TestMarkTokens):
   is_astroid_test = True
   module = astroid
 
-  nodes_classes = astroid.ALL_NODE_CLASSES
+  nodes_classes = NodeNG
   context_classes = [
     (astroid.Name, astroid.DelName, astroid.AssignName),
     (astroid.Attribute, astroid.DelAttr, astroid.AssignAttr),

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -9,6 +9,7 @@ import re
 import sys
 import textwrap
 import unittest
+from time import time
 
 import astroid
 import six
@@ -592,7 +593,13 @@ j  # not a complex number, just a name
 
   if six.PY3:
     def test_sys_modules(self):
+      start = time()
       for module in list(sys.modules.values()):
+        # Don't let this test (which runs twice) take longer than 13 minutes
+        # to avoid the travis build time limit of 30 minutes
+        if time() - start > 13 * 60:
+          break
+
         try:
           filename = inspect.getsourcefile(module)
         except TypeError:

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -608,6 +608,12 @@ j  # not a complex number, just a name
             source = f.read()
         except OSError:
           continue
+
+        # Astroid fails with a syntax error if a type comment is on its own line
+        if self.is_astroid_test and re.search(r'^\s*# type: ', source, re.MULTILINE):
+          print('Skipping', filename)
+          continue
+
         m = self.create_mark_checker(source)
 
         m.verify_all_nodes(self)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -698,7 +698,7 @@ j  # not a complex number, just a name
     else:
       # Weird bug in astroid that collapses spaces in docstrings sometimes maybe
       if self.is_astroid_test and isinstance(t1, six.string_types):
-        t1 = re.sub(r'^ +$', '', t1)
-        t2 = re.sub(r'^ +$', '', t2)
+        t1 = re.sub(r'^ +$', '', t1, re.MULTILINE)
+        t2 = re.sub(r'^ +$', '', t2, re.MULTILINE)
 
       self.assertEqual(t1, t2)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -593,8 +593,18 @@ j  # not a complex number, just a name
 
   if six.PY3:
     def test_sys_modules(self):
+      """
+      Verify all nodes on source files obtained from sys.modules.
+      This can take a long time as there are many modules,
+      so it only tests all modules if the environment variable
+      ASTTOKENS_SLOW_TESTS has been set.
+      """
+      modules = list(sys.modules.values())
+      if not os.environ.get('ASTTOKENS_SLOW_TESTS'):
+        modules = modules[:20]
+
       start = time()
-      for module in list(sys.modules.values()):
+      for module in modules:
         # Don't let this test (which runs twice) take longer than 13 minutes
         # to avoid the travis build time limit of 30 minutes
         if time() - start > 13 * 60:

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -698,7 +698,7 @@ j  # not a complex number, just a name
     else:
       # Weird bug in astroid that collapses spaces in docstrings sometimes maybe
       if self.is_astroid_test and isinstance(t1, six.string_types):
-        t1 = re.sub(r'^ +$', '', t1, re.MULTILINE)
-        t2 = re.sub(r'^ +$', '', t2, re.MULTILINE)
+        t1 = re.sub(r'^ +$', '', t1, flags=re.MULTILINE)
+        t2 = re.sub(r'^ +$', '', t2, flags=re.MULTILINE)
 
       self.assertEqual(t1, t2)

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,5 @@ whitelist_externals =
     sh
 deps =
     .[test]
+passenv =
+    ASTTOKENS_SLOW_TESTS

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py{27,35,36,37,38,py,py3}
 
 [testenv]
-commands = sh -c "pytest --disable-warnings tests/*.py"
+commands = pytest
 whitelist_externals =
     sh
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ envlist = py{27,35,36,37,38,py,py3}
 
 [testenv]
 commands = pytest
-whitelist_externals =
-    sh
 deps =
     .[test]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@
 envlist = py{27,35,36,37,38,py,py3}
 
 [testenv]
-commands = nosetests
+commands = sh -c "pytest --disable-warnings tests/*.py"
+whitelist_externals =
+    sh
 deps =
-    nose
-    coverage
+    pytest
     astroid

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,4 @@ commands = pytest
 whitelist_externals =
     sh
 deps =
-    pytest
-    astroid
+    .[test]


### PR DESCRIPTION
This is about various testing infrastructure improvements:

1. pytest instead of nose:

Whenever `ast.parse` fails with a SyntaxError inside a test, nose breaks and instead I get:

> AttributeError: 'SyntaxError' object has no attribute 'filename'

The problem doesn't happen with pytest and I'm getting more informative tracebacks too. nose is old now and [its own docs recommend not using it](https://nose.readthedocs.io/en/latest/). I think this would be a great improvement.

2. Coveralls: Travis now sends a coverage report to coveralls. See an example here: https://coveralls.io/builds/26516443

If you merge this you just need to sign up for coveralls and turn the repo on. Then you can add a badge to the README.

3. Speeding up astroid tests: the old astroid `assert_nodes_equal` builds up large strings just to compare them, and it's quite wasteful. Using the same algorithm for both to compare trees directly is significantly faster. This is important because the coverage tracer adds a lot of overhead, and it seems to be especially bad for pypy, which was exceeding the maximum allowed time of 30 minutes on travis. Even now it just barely makes it and we may need to place a time limit, something like [this](https://github.com/alexmojaki/asttokens/commit/45829e6343c0c00bdb32fd2427f13dd4ed37e788).

If you're happy with all this, I will also update the docs regarding testing.

I would also need to update `requirements[-top].txt`, but really I think it would be better to delete them. Having pinned versions (e.g. `astroid==1.5.3`!) is definitely bad, but even otherwise you can just do `pip install .[test]`.