### PR TITLE
Automatically call verify_all_nodes by default

### DIFF
--- a/tests/test_astroid.py
+++ b/tests/test_astroid.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, print_function
 import astroid
 from astroid.node_classes import NodeNG
 
+from asttokens import ASTTokens
 from . import tools, test_mark_tokens
 
 
@@ -31,8 +32,8 @@ class TestAstroid(test_mark_tokens.TestMarkTokens):
         continue
       yield field, getattr(node, field)
 
-  @classmethod
-  def create_mark_checker(cls, source):
+  @staticmethod
+  def create_asttokens(source):
     builder = astroid.builder.AstroidBuilder()
     tree = builder.string_build(source)
-    return tools.MarkChecker(source, tree=tree)
+    return ASTTokens(source, tree=tree)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 
-import asttokens
 from asttokens import util
 
 
@@ -36,8 +35,8 @@ class MarkChecker(object):
   """
   Helper tool to parse and mark an AST tree, with useful methods for verifying it.
   """
-  def __init__(self, source, parse=False, tree=None):
-    self.atok = asttokens.ASTTokens(source, parse=parse, tree=tree)
+  def __init__(self, atok):
+    self.atok = atok
     self.all_nodes = collect_nodes_preorder(self.atok.tree)
 
   def get_nodes_at(self, line, col):


### PR DESCRIPTION
This is branched from the branch in #42 so ignore all commits except the last one for now, they should disappear when #42 is merged.