### PR TITLE
Coveralls parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
 
 env:
   - ASTTOKENS_SLOW_TESTS=1
+  - COVERALLS_PARALLEL=true
 
 install:
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,6 @@ script:
 
 after_success:
   - coveralls
+
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ python:
   - pypy3.5
 
 env:
-  - ASTTOKENS_SLOW_TESTS=1
-  - COVERALLS_PARALLEL=true
+  global:
+    - ASTTOKENS_SLOW_TESTS=1
+    - COVERALLS_PARALLEL=true
 
 install:
   - pip install coveralls


### PR DESCRIPTION
Seems there's been a recent change in how Coveralls handles the different jobs in a build coming from Travis. This PR is based on the instructions here: https://docs.coveralls.io/parallel-build-webhook

See the difference between [before](https://coveralls.io/builds/26508337) and [after](https://coveralls.io/builds/26544244). Coverage from the same files is aggregated together, so:

1. Overall coverage has increased from 95% to 97%.
2. Files are not repeated for every job.
3. You can actually see which lines are never covered in any language version.