### PR TITLE
Added mark_node_specific_methods

### DIFF
--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -39,10 +39,14 @@ class ASTTokens(object):
   addition to the trees produced by the ``ast`` module, ASTTokens will also mark trees produced
   using ``astroid`` library <https://www.astroid.org>.
 
+  If ``mark_node_specific_methods`` is ``True``, then there will be trying
+  to specially handle an attribute node. The ``False`` value disables the handling.
+
   If only ``source_text`` is given, you may use ``.mark_tokens(tree)`` to mark the nodes of an AST
   tree created separately.
   """
-  def __init__(self, source_text, parse=False, tree=None, filename='<unknown>'):
+  def __init__(self, source_text, parse=False, tree=None, filename='<unknown>', mark_node_specific_methods=True):
+    self._mark_node_specific_methods = mark_node_specific_methods
     self._filename = filename
     self._tree = ast.parse(source_text, filename) if parse else tree
 

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -89,7 +89,10 @@ class MarkTokens(object):
     first, last = self._expand_to_matching_pairs(first, last, node)
 
     # Give a chance to node-specific methods to adjust.
-    nfirst, nlast = self._methods.get(self, node.__class__)(node, first, last)
+    if self._code._mark_node_specific_methods:
+      nfirst, nlast = self._methods.get(self, node.__class__)(node, first, last)
+    else:
+      nfirst, nlast = first, last
 
     if (nfirst, nlast) != (first, last):
       # If anything changed, expand again to capture any unmatched brackets.


### PR DESCRIPTION
Hello!

This PR closes #62 - support for [xonsh shell](https://xon.sh/contents.html) AST tree.

I've added `mark_node_specific_methods` boolean argument to `ASTTokens` constructor that allows to switch off special handling an AST attribute node.

Switching this handling off allows to parse xonsh shell tree. Example:

```python
# To run this code just do `pip install xonsh`, run `xonsh` and copy-paste this code
import ast, asttokens

st="echo @('hello' + 'world' + str(123)) | head"

atok = asttokens.ASTTokens(
                source_text=st, 
                parse=False,
                tree=__xonsh__.execer.parse(st, ctx=__xonsh__.ctx),
                mark_node_specific_methods=False # ADDED
                )

for node in ast.walk(atok.tree):
    if hasattr(node, 'lineno'):
        print(f"range={atok.get_text_range(node)}, node={node.__class__.__name__}, text={repr(atok.get_text(node))}")
```
Output:
```
range=(0, 43), node=Expression, text="echo @('hello' + 'world' + str(123)) | head"
range=(0, 43), node=Call, text="echo @('hello' + 'world' + str(123)) | head"
range=(0, 4), node=Attribute, text='echo'
range=(0, 36), node=BinOp, text="echo @('hello' + 'world' + str(123))"
range=(39, 43), node=Constant, text='head'
range=(39, 43), node=List, text='head'
range=(0, 4), node=Name, text='echo'
range=(0, 4), node=List, text='echo'
range=(7, 35), node=Call, text="'hello' + 'world' + str(123)"
range=(39, 43), node=Call, text='head'
range=(0, 4), node=Call, text='echo'
range=(7, 14), node=Attribute, text="'hello'"
range=(7, 35), node=BinOp, text="'hello' + 'world' + str(123)"
range=(39, 43), node=Attribute, text='head'
range=(39, 43), node=Constant, text='head'
range=(0, 4), node=Attribute, text='echo'
range=(0, 4), node=Constant, text='echo'
range=(7, 14), node=Name, text="'hello'"
range=(7, 24), node=BinOp, text="'hello' + 'world'"
range=(0, 0), node=Add, text=''
range=(27, 35), node=Call, text='str(123)'
range=(39, 43), node=Name, text='head'
range=(0, 4), node=Name, text='echo'
range=(7, 14), node=Constant, text="'hello'"
range=(0, 0), node=Add, text=''
range=(17, 24), node=Constant, text="'world'"
range=(27, 30), node=Name, text='str'
range=(31, 34), node=Constant, text='123'
```
