### PR TITLE
setup.cfg: remove wheel dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 packages = asttokens
 install_requires = six
-setup_requires = setuptools>=44; wheel; setuptools_scm[toml]>=3.4.3
+setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 
 [options.extras_require]
 test = astroid; pytest


### PR DESCRIPTION
This shouldn't be a hard dependency since it's required only
when building binary wheels.

Signed-off-by: Asaf Kahlon <asafka7@gmail.com>