### PR TITLE
Correctly mark slice token spans.

### DIFF
--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -236,6 +236,25 @@ class MarkTokens(object):
     last_token = self.handle_following_brackets(node, last_token, '[')
     return (first_token, last_token)
 
+  def visit_slice(self, node, first_token, last_token):
+    # consume `:` tokens to the left and right. In Python 3.9, Slice nodes are
+    # given a col_offset, (and end_col_offset), so this will always start inside
+    # the slice, even if it is the empty slice. However, in 3.8 and below, this
+    # will only expand to the full slice if the slice contains a node with a
+    # col_offset. So x[:] will only get the correct tokens in 3.9, but x[1:] and
+    # x[:1] will even on earlier versions of Python.
+    while True:
+      prev = self._code.prev_token(first_token)
+      if prev.string != ':':
+        break
+      first_token = prev
+    while True:
+      next_ = self._code.next_token(last_token)
+      if next_.string != ':':
+        break
+      last_token = next_
+    return (first_token, last_token)
+
   def handle_bare_tuple(self, node, first_token, last_token):
     # A bare tuple doesn't include parens; if there is a trailing comma, make it part of the tuple.
     maybe_comma = self._code.next_token(last_token)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -151,7 +151,7 @@ b +     # line3
     'astroid/email.py':               ( 3,    3,    1,    1,   ),
     'astroid/format.py':              ( 64,   61,   62,   62,  ),
     'astroid/module.py':              ( 185,  174,  171,  171, ),
-    'astroid/module2.py':             ( 248,  253,  240,  253, ),
+    'astroid/module2.py':             ( 248,  255,  240,  253, ),
     'astroid/noendingnewline.py':     ( 57,   59,   57,   63,  ),
     'astroid/notall.py':              ( 15,   17,   15,   17,  ),
     'astroid/recursion.py':           ( 6,    6,    4,    4,   ),
@@ -729,11 +729,14 @@ partial_sums = [total := total + v for v in values]
     # string contained in an astroid.Const or astroid.Expr it will end up in the doc attribute and be
     # a pain to extract for comparison
     # For starred expressions, e.g. `*args`, we wrap it in a function call to make it parsable.
+    # For slices, e.g. `x:`, we wrap it in an indexing expression to make it parsable.
     indented = re.match(r'^[ \t]+\S', text)
     if indented:
       return self.module.parse('def dummy():\n' + text).body[0].body[0]
     if util.is_starred(node):
       return self.module.parse('f(' + text + ')').body[0].value.args[0]
+    if util.is_slice(node):
+      return self.module.parse('a[' + text + ']').body[0].value.slice
     if util.is_expr(node):
       return self.module.parse('_\n(' + text + ')').body[1].value
     if util.is_module(node):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -74,10 +74,11 @@ class MarkChecker(object):
       if not (
           util.is_stmt(node) or
           util.is_expr(node) or
-          util.is_module(node)
-        # In 3.9+, slices are now expressions in the AST, but of course their source code
-        # can't be parsed
-      ) or util.is_slice(node):
+          util.is_module(node)):
+        continue
+
+      # slices currently only get the correct tokens for ast, not astroid.
+      if util.is_slice(node) and test_case.is_astroid_test:
         continue
 
       text = self.atok.get_text(node)


### PR DESCRIPTION
Previous to this, the slice `x[1:]` would have the token span for `1`, instead of `1:`.

This is not the ideal way to do it -- I think ideally, mark_tokens should be using both `col_offset` and `end_col_offset`, in which case this would have worked automatically on Python 3.9. But this does get it working "as much as possible" in versions prior to 3.9.

In particular: while slices like `1:` and `:1` will now work correctly in Python 3.8-, the slice `x[:]` will still get attributed to `x` and not `:`. Oops. That issue does not exist in 3.9 (before or after this change).