### PR TITLE
Workaround Python tokenize bug with non-ASCII characters

### DIFF
--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -17,7 +17,7 @@ import bisect
 import io
 import token
 import tokenize
-from .util import Token, match_token, is_non_coding_token, AstNode
+from .util import Token, match_token, is_non_coding_token, AstNode, patched_generate_tokens
 import six
 from six.moves import xrange      # pylint: disable=redefined-builtin
 from .line_numbers import LineNumbers
@@ -87,10 +87,11 @@ class ASTTokens(object):
     """
     Generates tokens for the given code.
     """
-    # This is technically an undocumented API for Python3, but allows us to use the same API as for
+    # tokenize.generate_tokens is technically an undocumented API for Python3, but allows us to use the same API as for
     # Python2. See http://stackoverflow.com/a/4952291/328565.
     # FIXME: Remove cast once https://github.com/python/typeshed/issues/7003 gets fixed
-    for index, tok in enumerate(tokenize.generate_tokens(cast(Callable[[], str], io.StringIO(text).readline))):
+    original_tokens = tokenize.generate_tokens(cast(Callable[[], str], io.StringIO(text).readline))
+    for index, tok in enumerate(patched_generate_tokens(original_tokens)):
       tok_type, tok_str, start, end, line = tok
       yield Token(tok_type, tok_str, start, end, line, index,
                   self._line_numbers.line_to_offset(start[0], start[1]),

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -345,7 +345,8 @@ else:
       else:
         for combined_token in combine_tokens(group):
           yield combined_token
-        group = [tok]
+        group = []
+        yield tok
     for combined_token in combine_tokens(group):
       yield combined_token
 

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -318,8 +318,7 @@ class NodeMethods(object):
     return method
 
 
-def patched_generate_tokens(original_tokens):
-  # type: (Iterator[tokenize.TokenInfo]) -> Iterator[tokenize.TokenInfo]
+def patched_generate_tokens(original_tokens):  # type: ignore  # (Python 2 makes it hard)
   """
   Fixes tokens yielded by `tokenize.generate_tokens` to handle more non-ASCII characters in identifiers.
   Workaround for https://github.com/python/cpython/issues/68382.
@@ -338,9 +337,9 @@ def patched_generate_tokens(original_tokens):
       original_tokens,
       lambda t: tokenize.NAME if t.type == tokenize.ERRORTOKEN else t.type,
   ):
-    group = list(group_iter)  # type: List[tokenize.TokenInfo]
+    group = list(group_iter)
     if key == tokenize.NAME and len(group) > 1 and any(tok.type == tokenize.ERRORTOKEN for tok in group):
-      line = group[0].line  # type: str
+      line = group[0].line
       assert {tok.line for tok in group} == {line}
       yield tokenize.TokenInfo(
         type=tokenize.NAME,

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -334,11 +334,11 @@ def patched_generate_tokens(original_tokens):
       yield tok
     return
 
-  for key, group in itertools.groupby(
+  for key, group_iter in itertools.groupby(
       original_tokens,
       lambda t: tokenize.NAME if t.type == tokenize.ERRORTOKEN else t.type,
   ):
-    group = list(group)  # type: List[tokenize.TokenInfo]
+    group = list(group_iter)  # type: List[tokenize.TokenInfo]
     if key == tokenize.NAME and len(group) > 1 and any(tok.type == tokenize.ERRORTOKEN for tok in group):
       line = group[0].line  # type: str
       assert {tok.line for tok in group} == {line}

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -635,8 +635,19 @@ j  # not a complex number, just a name
         except OSError:
           continue
 
-        # Astroid fails with a syntax error if a type comment is on its own line
-        if self.is_astroid_test and re.search(r'^\s*# type: ', source, re.MULTILINE):
+        if self.is_astroid_test and (
+            # Astroid fails with a syntax error if a type comment is on its own line
+            re.search(r'^\s*# type: ', source, re.MULTILINE)
+            # Astroid can fail on this file, specifically raising an exception at this line of code:
+            #     lambda node: node.name == "NamedTuple" and node.parent.name == "typing"
+            # with the error:
+            #     AttributeError: 'If' object has no attribute 'name'
+            # See https://github.com/gristlabs/asttokens/runs/7602147792
+            # I think the code that causes the problem is:
+            #     if sys.version_info >= (3, 11):
+            #         NamedTuple = typing.NamedTuple
+            or filename.endswith("typing_extensions.py")
+        ):
           print('Skipping', filename)
           continue
 

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -284,7 +284,7 @@ bar = ('x y z'   # comment2
       # Test of https://bitbucket.org/plas/thonny/issues/162/weird-range-marker-crash-with-non-ascii
       # Only on PY3 because Py2 doesn't support unicode identifiers.
       for source in (
-        "℘·=1",  # example from https://github.com/python/cpython/issues/68382
+        "℘·2=1",  # example from https://github.com/python/cpython/issues/68382
         "sünnikuupäev=str((18+int(isikukood[0:1])-1)//2)+isikukood[1:3]",
         "sünnikuupaev=str((18+int(isikukood[0:1])-1)//2)+isikukood[1:3]"):
         m = self.create_mark_checker(source)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -284,7 +284,7 @@ bar = ('x y z'   # comment2
       # Test of https://bitbucket.org/plas/thonny/issues/162/weird-range-marker-crash-with-non-ascii
       # Only on PY3 because Py2 doesn't support unicode identifiers.
       for source in (
-        "℘·2=1",  # example from https://github.com/python/cpython/issues/68382
+        "℘·2=1+a℘·b+a℘·2b",  # example from https://github.com/python/cpython/issues/68382
         "sünnikuupäev=str((18+int(isikukood[0:1])-1)//2)+isikukood[1:3]",
         "sünnikuupaev=str((18+int(isikukood[0:1])-1)//2)+isikukood[1:3]"):
         m = self.create_mark_checker(source)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -284,13 +284,14 @@ bar = ('x y z'   # comment2
       # Test of https://bitbucket.org/plas/thonny/issues/162/weird-range-marker-crash-with-non-ascii
       # Only on PY3 because Py2 doesn't support unicode identifiers.
       for source in (
+        "℘·=1",  # example from https://github.com/python/cpython/issues/68382
         "sünnikuupäev=str((18+int(isikukood[0:1])-1)//2)+isikukood[1:3]",
         "sünnikuupaev=str((18+int(isikukood[0:1])-1)//2)+isikukood[1:3]"):
         m = self.create_mark_checker(source)
         self.assertEqual(m.view_nodes_at(1, 0), {
           "Module:%s" % source,
           "Assign:%s" % source,
-          "%s:%s" % ("AssignName" if self.is_astroid_test else "Name", source[:12])
+          "%s:%s" % ("AssignName" if self.is_astroid_test else "Name", source.split("=")[0]),
         })
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -143,6 +143,9 @@ if six.PY3:
       TokenInfo(NAME, string='℘·2', start=(1, 0), end=(1, 3), line='℘·2=1'),
       TokenInfo(OP, string='=', start=(1, 3), end=(1, 4), line='℘·2=1'),
     ]
+    assert list(patched_generate_tokens(iter(original_tokens[:-1]))) == [
+      TokenInfo(NAME, string='℘·2', start=(1, 0), end=(1, 3), line='℘·2=1'),
+    ]
 
 
 if __name__ == "__main__":

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -122,8 +122,8 @@ if six.PY3:
     from asttokens.util import combine_tokens, patched_generate_tokens
 
     text = "℘·2=1"
-    original_tokens = list(generate_tokens(io.StringIO(text).readline))
-    assert original_tokens[:4] == [
+    original_tokens = list(generate_tokens(io.StringIO(text).readline))[:4]
+    assert original_tokens == [
       TokenInfo(ERRORTOKEN, string='℘', start=(1, 0), end=(1, 1), line='℘·2=1'),
       TokenInfo(ERRORTOKEN, string='·', start=(1, 1), end=(1, 2), line='℘·2=1'),
       TokenInfo(NUMBER, string='2', start=(1, 2), end=(1, 3), line='℘·2=1'),
@@ -139,7 +139,7 @@ if six.PY3:
       TokenInfo(NAME, string='℘·2', start=(1, 0), end=(1, 3), line='℘·2=1'),
     ]
 
-    assert list(patched_generate_tokens(iter(original_tokens)))[:2] == [
+    assert list(patched_generate_tokens(iter(original_tokens))) == [
       TokenInfo(NAME, string='℘·2', start=(1, 0), end=(1, 3), line='℘·2=1'),
       TokenInfo(OP, string='=', start=(1, 3), end=(1, 4), line='℘·2=1'),
     ]


### PR DESCRIPTION
Workaround for https://github.com/python/cpython/issues/68382

I ran into this recently in futurecoder and implemented the core logic in https://github.com/alexmojaki/futurecoder/pull/373/commits/ea8bed30f9eaa795179b5beebe2e026ee53ee0e8#diff-2439d77444f0be435d92d3e5df78ab2f065592d4f66c075a1bc92e1b8bb41954R25-R46 to support variable names translated to Tamil. But monkeypatching `tokenize` globally leads to incorrect behaviour with actually invalid code, which for example causes friendly-traceback to explain syntax errors incorrectly. Besides, this fix belongs here.