### PR TITLE
Allow triggering GitHub actions workflow manually

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/gristlabs/asttokens/pull/82 ran into some extreme corner case (I don't know the details yet) and I wanted to check if the same failure also happened on master. According to https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow, something like this is needed to enable what I wanted to do.