### PR TITLE
Fix mypy explicit re-export issues

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Not an exact mypy version, as we need 0.942 for pypy-3.8 support, but it's not available on 3.5
           pip install types-six "mypy>=0.910,<=0.942"
-          python -m mypy asttokens
+          python -m mypy asttokens tests
         # fromJson because https://github.community/t/passing-an-array-literal-to-contains-function-causes-syntax-error/17213/3
         if: ${{ !contains(fromJson('["2.7", "pypy-2.7", "pypy-3.6", "pypy-3.7"]'), matrix.python-version) }}
         # pypy < 3.8 very doesn't work

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           # Not an exact mypy version, as we need 0.942 for pypy-3.8 support, but it's not available on 3.5
           pip install types-six "mypy>=0.910,<=0.942"
-          python -m mypy asttokens tests
+          python -m mypy asttokens tests/*.py
         # fromJson because https://github.community/t/passing-an-array-literal-to-contains-function-causes-syntax-error/17213/3
         if: ${{ !contains(fromJson('["2.7", "pypy-2.7", "pypy-3.6", "pypy-3.7"]'), matrix.python-version) }}
         # pypy < 3.8 very doesn't work

--- a/asttokens/__init__.py
+++ b/asttokens/__init__.py
@@ -20,3 +20,5 @@ transformations.
 
 from .line_numbers import LineNumbers
 from .asttokens import ASTTokens
+
+__all__ = ['ASTTokens', 'LineNumbers']

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -26,7 +26,7 @@ from .asttokens import ASTTokens
 from .util import AstConstant
 
 try:
-  import astroid.node_classes as nc # type: ignore[import]
+  import astroid.node_classes as nc
 except Exception:
   # This is only used for type checking, we don't need it if astroid isn't installed.
   nc = None

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -24,7 +24,7 @@ from typing import Callable, Dict, Iterator, List, Optional, Tuple, Union, cast,
 from six import iteritems
 
 if TYPE_CHECKING:
-  from astroid.node_classes import NodeNG  # type: ignore[import]
+  from astroid.node_classes import NodeNG
 
   # Type class used to expand out the definition of AST to include fields added by this library
   # It's not actually used for anything other than type checking though!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ warn_unused_ignores=true
 disallow_untyped_defs=true
 disallow_untyped_calls=true
 no_implicit_reexport=true
-exclude = ["testdata"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ warn_unused_ignores=true
 disallow_untyped_defs=true
 disallow_untyped_calls=true
 no_implicit_reexport=true
+exclude = ["testdata"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,14 @@ show_error_codes=true
 warn_unused_ignores=true
 disallow_untyped_defs=true
 disallow_untyped_calls=true
+no_implicit_reexport=true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs=false
+disallow_untyped_calls=false
+ignore_missing_imports=true
+
+[[tool.mypy.overrides]]
+module = ["astroid", "astroid.node_classes"]
+ignore_missing_imports = true

--- a/tests/context.py
+++ b/tests/context.py
@@ -3,3 +3,5 @@ from os.path import abspath, dirname
 sys.path.insert(0, dirname(dirname(abspath(__file__))))
 
 import asttokens
+
+__all__ = ["asttokens"]

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -9,6 +9,7 @@ import re
 import sys
 import textwrap
 import token
+from typing import List
 import unittest
 from time import time
 
@@ -787,7 +788,7 @@ partial_sums = [total := total + v for v in values]
           'def foo():\n    """xx"""\n    None')
 
   nodes_classes = ast.AST
-  context_classes = [ast.expr_context] # type: list[util.AstNode]
+  context_classes = [ast.expr_context] # type: List[util.AstNode]
   iter_fields = staticmethod(ast.iter_fields)
 
   def assert_nodes_equal(self, t1, t2):

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -787,7 +787,7 @@ partial_sums = [total := total + v for v in values]
           'def foo():\n    """xx"""\n    None')
 
   nodes_classes = ast.AST
-  context_classes = [ast.expr_context]
+  context_classes = [ast.expr_context] # type: list[util.AstNode]
   iter_fields = staticmethod(ast.iter_fields)
 
   def assert_nodes_equal(self, t1, t2):


### PR DESCRIPTION
Fixes https://github.com/gristlabs/asttokens/issues/89. The easiest way to get an example that exercised enough things was to re-use the test code. It's got _very_ loose typing settings for the moment, as it doesn't really need that much to reproduce the error in this case and making the tests fully typed would be a lot more effort!