### PR TITLE
Try to optimise bracket matching.

### DIFF
--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
   from .util import AstNode
 
 
+from .intervaltree import make_tree
+
+
 class ASTTokens(object):
   """
   ASTTokens maintains the text of Python code in several forms: as a string, as line numbers, and
@@ -65,6 +68,7 @@ class ASTTokens(object):
 
     # Tokenize the code.
     self._tokens = list(self._generate_tokens(source_text))
+    self._tp = make_tree(self._tokens)
 
     # Extract the start positions of all tokens, so that we can quickly map positions to tokens.
     self._token_offsets = [tok.startpos for tok in self._tokens]

--- a/asttokens/intervaltree.py
+++ b/asttokens/intervaltree.py
@@ -1,0 +1,188 @@
+from textwrap import indent
+from operator import attrgetter
+from bisect import bisect_right, bisect_left
+import token
+
+
+class IntervalTree:
+  """
+    The intervalTree is storing nested, consecutive interval in order to quickly
+    query a location for the preceding/following opening or closing parenthesis.
+
+    It only stores the index of the tokens that are []{} or ().
+
+    Leaves nodes are always completely included in their parents.
+    for example the following sequence, excluding non brackets.
+
+    Note that is is not the generic interval tree, as child nodes are strictly
+    included in their parents, and no two child overlap.
+
+    Plus for efficiency and simplicity the child are dense, that is to say the
+    c1.high == c2.low-1.
+
+
+    We have 3 types of nodes:
+    - The root – it has children, but an interval query should not extend to
+      boundary.
+    - IntervalTree node, represent a Pair of balanced bracket.
+       - If the query contain a boundary, we extend the interval to the full
+         node length and return.
+       - If not, we recurse in children.
+         - either both end of the query are included in a child
+         - both ends are in different child.
+    - EmptyNode nodes (leaves), are range of tokens that don't contain imbalanced
+      brackets. When hitting those we don't need to extend the range.
+      We _can_ have a tree without those nodes, but it ends up being more
+      complicated and slower with the extra logic. Here we can just bisect
+      children and recurse no matter what.
+
+
+  """
+
+  def __init__(self, low, high=float('inf')):
+    self.low = low
+    self.high = high
+    # empty node well remove later, this make creating the tree easier as we
+    # don't have to check whether children is empty in append.
+    self.children = [EmptyNode(low,low)]
+    self._low = []
+    self._high = []
+
+
+  def append(self, node):
+    prev = self.children[-1]
+    if node.low != prev.high+1:
+      self.children.append(EmptyNode(prev.high+1, node.low-1))
+    self.children.append(node)
+
+  def finalize(self):
+    """
+    the tree is constructed, finalize it for faster query
+    remove the Empty(low, low) from __init__, maybe append and empty
+    node at eh end to have the children be dense (help edge cases with bisect
+    queries) and precompute _low and _high, to avoid using
+    `key=attributegetter(...)` in bisect with make bisect much slower.
+
+    """
+
+    for c in self.children:
+      c.finalize()
+    if self.children[-1].high < self.high -1:
+      self.children.append(EmptyNode(self.children[-1].high+1, self.high-1))
+    self.children.pop(0)
+    self._low = [c.low for low in self.children]
+    self._high = [c.high for low in self.children]
+
+  def query_interval(self, low, high):
+    """
+    Find smaller encompassing interval that contains [low, high]
+
+    For this type of node if one boundary is included, we can extend
+    to the other boundary as an optimisation.
+
+    For example:
+
+        ( a + b + [ c ] * 3 )
+        ^        ^high
+        low                 ^
+                            extend to there.
+    """
+
+    if low == self.low:
+       return low, self.high
+    if high == self.high:
+       return self.low, high
+    return self._query_interval(low, high)
+
+  def _query_interval(self, low, high):
+    """
+    ... here we are strictly included recurse in children.
+
+
+        ( a + b + [ c ] * 3 )
+          ^         ^ high
+         low
+
+        we'll querry the "a + b +" node with low
+        and the "[ c ]" range with high.
+    """
+
+    lowi = bisect_right(self._low, low)-1
+    A = self.children[lowi]
+
+    if high <= A.high:
+      low, high = A.query_interval(low, high)
+    else:
+      hii = bisect_left(self._high, high)
+      B = self.children[hii]
+      low = A.query_low(low)
+      high = B.query_high(high)
+    return low, high
+
+
+  def query_high(self, high):
+    """
+    We are in an imbalanced interval, return our max
+    """
+    return self.high
+
+  def query_low(self, low):
+    """
+    We are in an imbalanced interval, return our min
+    """
+    return self.low
+
+  def __repr__(self):
+    rs = [repr(c) for c in self.children]
+    ch = '\n'+indent( '\n'.join(rs), '  ') if rs else ''
+    return f"{self.low}-{self.high}{ch}"
+
+class Root(IntervalTree):
+
+  def query_interval(self, low, high):
+    """
+    The root is the only node that has children
+    but no matching pairs at both ends.
+    So we do not skip the parent logic.
+    """
+    return self._query_interval(low, high)
+
+class EmptyNode(IntervalTree):
+  """
+  No imbalanced bracket in this interval.
+  """
+
+  def __init__(self, low, high):
+    self.low = low
+    self.high = high
+
+  def query_interval(self, low, high):
+    return low, high
+
+  def query_high(self, high):
+    return high
+
+  def query_low(self, low):
+    return low
+
+  def finalize(self):
+    pass
+
+  def __repr__(self):
+    return f"{self.low}-{self.high} - Empty {self.high-self.low}"
+
+def make_tree(toks):
+  stack = [Root(0,len(toks))]
+  for i,t in enumerate(toks):
+    if t.type == token.OP:
+      if t.string in '[{(':
+        node = IntervalTree(i)
+        stack[-1].append(node)
+        stack.append(node)
+      elif t.string in ']})':
+        node = stack.pop()
+        node.high = i
+  assert len(stack) == 1
+  root = stack[0]
+  root.finalize()
+  return root

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -105,14 +105,14 @@ class MarkTokens(object):
       last = self._find_last_in_stmt(cast(util.Token, last))
 
     # Capture any unmatched brackets.
-    first, last = self._expand_to_matching_pairs(cast(util.Token, first), cast(util.Token, last), node)
+    first, last = self._expand_to_matching_pairs_fast(cast(util.Token, first), cast(util.Token, last))
 
     # Give a chance to node-specific methods to adjust.
     nfirst, nlast = self._methods.get(self, node.__class__)(node, first, last)
 
     if (nfirst, nlast) != (first, last):
       # If anything changed, expand again to capture any unmatched brackets.
-      nfirst, nlast = self._expand_to_matching_pairs(nfirst, nlast, node)
+      nfirst, nlast = self._expand_to_matching_pairs_fast(nfirst, nlast)
 
     node.first_token = nfirst
     node.last_token = nlast
@@ -125,6 +125,10 @@ class MarkTokens(object):
            not token.ISEOF(t.type)):
       t = self._code.next_token(t, include_extra=True)
     return self._code.prev_token(t)
+
+  def _expand_to_matching_pairs_fast(self, first_token, last_token):
+    ll,hh = self._code._tp.query_interval(first_token.index, last_token.index)
+    return self._code._tokens[ll], self._code._tokens[hh]
 
   def _expand_to_matching_pairs(self, first_token, last_token, node):
     # type: (util.Token, util.Token, AstNode) -> Tuple[util.Token, util.Token]


### PR DESCRIPTION
Related to ipython/ipython#13731

Finding matching brackets in in some cases, this is one of the slowest operation.

Test script:

> import pandas.core.series as ps
> from asttokens import ASTTokens
> from pathlib import Path
>
> text = Path(ps.__file__).read_text()
>
> for i in range(10):
>     ASTTokens(text, True)

$ time python opt.py
python opt.py  1.91s user 0.14s system 122% cpu 1.674 total

vs master branch

python opt.py  2.20s user 0.13s system 119% cpu 1.957 total

In the tree-visit step for the specific above example this reduces the
time matching brackets from 2/3 of the function time (it is call in 2
places), to arround 20%, so about a x3 speed increase.

I want to make sure you are ok with this approach before going further
as I have spent already quite a bit of time on this

The line profiling also gives the following on master branch:

    Total time: 2.53663 s
    Function: _visit_after_children at line 81

    Line #      Hits         Time  Per Hit   % Time  Line Contents
    ==============================================================
        81                                             @profile
        82                                             def _visit_after_children(self, node, parent_token, token):
        83                                               # type: (AstNode, Optional[util.Token], Optional[util.Token]) -> None
        84                                               # This processes the node generically first, after all children have been processed.
        85
        86                                               # Get the first and last tokens that belong to children. Note how this doesn't assume that we
        87                                               # iterate through children in order that corresponds to occurrence in source code. This
        88                                               # assumption can fail (e.g. with return annotations).
        89     69940      18300.0      0.3      0.7      first = token
        90     69940      18611.0      0.3      0.7      last = None
        91    139870     365826.0      2.6     14.4      for child in cast(Callable, self._iter_children)(node):
        92     69930      26697.0      0.4      1.1        if not first or child.first_token.index < first.index:
        93      2240        658.0      0.3      0.0          first = child.first_token
        94     69930      21753.0      0.3      0.9        if not last or child.last_token.index > last.index:
        95     66260      19586.0      0.3      0.8          last = child.last_token
        96
        97                                               # If we don't have a first token from _visit_before_children, and there were no children, then
        98                                               # use the parent's token as the first token.
        99     69940      19504.0      0.3      0.8      first = first or parent_token
       100
       101                                               # If no children, set last token to the first one.
       102     69940      18191.0      0.3      0.7      last = last or first
       103
       104                                               # Statements continue to before NEWLINE. This helps cover a few different cases at once.
       105     69940      39496.0      0.6      1.6      if util.is_stmt(node):
       106     10310      49476.0      4.8      2.0        last = self._find_last_in_stmt(cast(util.Token, last))
       107
       108                                               # Capture any unmatched brackets.
       109     69940    1532993.0     21.9     60.4      first, last = self._expand_to_matching_pairs(cast(util.Token, first), cast(util.Token, last), node)
       110
       111                                               # Give a chance to node-specific methods to adjust.
       112     69940     183633.0      2.6      7.2      nfirst, nlast = self._methods.get(self, node.__class__)(node, first, last)
       113
       114     69940      24949.0      0.4      1.0      if (nfirst, nlast) != (first, last):
       115                                                 # If anything changed, expand again to capture any unmatched brackets.
       116      7580     154927.0     20.4      6.1        nfirst, nlast = self._expand_to_matching_pairs(nfirst, nlast, node)
       117
       118     69940      21861.0      0.3      0.9      node.first_token = nfirst
       119     69940      20169.0      0.3      0.8      node.last_token = nlast


And on this PR:

    Total time: 1.08657 s
    Function: _visit_after_children at line 81

    Line #      Hits         Time  Per Hit   % Time  Line Contents
    ==============================================================
        81                                             @profile
        82                                             def _visit_after_children(self, node, parent_token, token):
        83                                               # type: (AstNode, Optional[util.Token], Optional[util.Token]) -> None
        84                                               # This processes the node generically first, after all children have been processed.
        85
        86                                               # Get the first and last tokens that belong to children. Note how this doesn't assume that we
        87                                               # iterate through children in order that corresponds to occurrence in source code. This
        88                                               # assumption can fail (e.g. with return annotations).
        89     69940      18259.0      0.3      1.7      first = token
        90     69940      18593.0      0.3      1.7      last = None
        91    139870     366285.0      2.6     33.7      for child in cast(Callable, self._iter_children)(node):
        92     69930      27234.0      0.4      2.5        if not first or child.first_token.index < first.index:
        93      2240        730.0      0.3      0.1          first = child.first_token
        94     69930      22926.0      0.3      2.1        if not last or child.last_token.index > last.index:
        95     66260      20105.0      0.3      1.9          last = child.last_token
        96
        97                                               # If we don't have a first token from _visit_before_children, and there were no children, then
        98                                               # use the parent's token as the first token.
        99     69940      19850.0      0.3      1.8      first = first or parent_token
       100
       101                                               # If no children, set last token to the first one.
       102     69940      19385.0      0.3      1.8      last = last or first
       103
       104                                               # Statements continue to before NEWLINE. This helps cover a few different cases at once.
       105     69940      39364.0      0.6      3.6      if util.is_stmt(node):
       106     10310      60294.0      5.8      5.5        last = self._find_last_in_stmt(cast(util.Token, last))
       107
       108                                               # Capture any unmatched brackets.
       109     69940     195805.0      2.8     18.0      first, last = self._expand_to_matching_pairs_fast(cast(util.Token, first), cast(util.Token, last))
       110
       111                                               # Give a chance to node-specific methods to adjust.
       112     69940     190991.0      2.7     17.6      nfirst, nlast = self._methods.get(self, node.__class__)(node, first, last)
       113
       114     69940      25562.0      0.4      2.4      if (nfirst, nlast) != (first, last):
       115                                                 # If anything changed, expand again to capture any unmatched brackets.
       116      7580      17687.0      2.3      1.6        nfirst, nlast = self._expand_to_matching_pairs_fast(nfirst, nlast)
       117
       118     69940      22287.0      0.3      2.1      node.first_token = nfirst
       119     69940      21214.0      0.3      2.0      node.last_token = nlast

I'm still not super happy with the speed, but we are closer to the speed
of tokenize.

    Line #      Hits         Time  Per Hit   % Time  Line Contents
    ==============================================================
        53                                             @profile
        54                                             def __init__(self, source_text, parse=False, tree=None, filename='<unknown>'):
        55                                               # type: (Any, bool, Optional[Module], str) -> None
        56                                               # FIXME: Strictly, the type of source_type is one of the six string types, but hard to specify with mypy given
        57                                               # https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
        58
        59        10         16.0      1.6      0.0      self._filename = filename
        60        10     139398.0  13939.8      2.8      self._tree = ast.parse(source_text, filename) if parse else tree
        61
        62                                               # Decode source after parsing to let Python 2 handle coding declarations.
        63                                               # (If the encoding was not utf-8 compatible, then even if it parses correctly,
        64                                               # we'll fail with a unicode error here.)
        65        10         55.0      5.5      0.0      source_text = six.ensure_text(source_text)
        66
        67        10          6.0      0.6      0.0      self._text = source_text
        68        10      25998.0   2599.8      0.5      self._line_numbers = LineNumbers(source_text)
        69
        70                                               # Tokenize the code.
        71        10    2646430.0 264643.0     53.4      self._tokens = list(self._generate_tokens(source_text))
        72        10     146805.0  14680.5      3.0      self._tp = make_tree(self._tokens)
        73
        74                                               # Extract the start positions of all tokens, so that we can quickly map positions to tokens.
        75        10      12838.0   1283.8      0.3      self._token_offsets = [tok.startpos for tok in self._tokens]
        76
        77        10         10.0      1.0      0.0      if self._tree:
        78        10    1988787.0 198878.7     40.1        self.mark_tokens(self._tree)