### PR TITLE
Versions of get_text and get_text_range that don't need mark_tokens

### DIFF
--- a/asttokens/line_numbers.py
+++ b/asttokens/line_numbers.py
@@ -63,6 +63,13 @@ class LineNumbers(object):
     else:
       return min(self._line_offsets[line] + max(0, column), self._text_len)
 
+  def utf8_to_offset(self, line, utf8_column):
+    # type: (int, int) -> int
+    """
+    Converts 1-based line number and 0-based utf8 column to 0-based character offset into text.
+    """
+    return self.line_to_offset(line, self.from_utf8_col(line, utf8_column))
+
   def offset_to_line(self, offset):
     # type: (int) -> Tuple[int, int]
     """

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -361,3 +361,18 @@ else:
         line=group[0].line,
       )
     ]
+
+
+def last_stmt(node):
+  # type: (ast.AST) -> ast.AST
+  """
+  If the given AST node contains multiple statements, return the last one.
+  Otherwise, just return the node.
+  """
+  child_stmts = [
+    child for child in ast.iter_child_nodes(node)
+    if isinstance(child, (ast.stmt, ast.excepthandler))
+  ]
+  if child_stmts:
+    return last_stmt(child_stmts[-1])
+  return node

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -442,6 +442,16 @@ bar = ('x y z'   # comment2
     self.assertEqual(m.view_nodes_at(2, 4), {'Name:x', 'Subscript:x[4]'})
 
   if not six.PY2:
+    def test_bad_unmarked_types(self):
+      # Cases where get_text_unmarked is incorrect in 3.8.
+      source = textwrap.dedent("""
+        def foo(*, name: str):  # keyword-only argument with type annotation
+          pass
+        
+        f(*(x))  # ast.Starred with parentheses
+      """)
+      self.create_mark_checker(source)
+
     def test_return_annotation(self):
       # See https://bitbucket.org/plas/thonny/issues/9/range-marker-crashes-on-function-return
       source = textwrap.dedent("""
@@ -554,11 +564,14 @@ a; b; c(
   17
 ); d # comment1; comment2
 if 2: a; b; # comment3
+if a:
+  if b: c; d  # comment4
     """
     m = self.create_mark_checker(source)
     self.assertEqual(
       [m.atok.get_text(n) for n in m.all_nodes if util.is_stmt(n)],
-      ['a', 'b', 'c(\n  17\n)', 'd', 'if 2: a; b', 'a', 'b'])
+      ['a', 'b', 'c(\n  17\n)', 'd', 'if 2: a; b', 'a', 'b',
+       'if a:\n  if b: c; d', 'if b: c; d', 'c', 'd'])
 
 
   def test_complex_numbers(self):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -143,20 +143,22 @@ class MarkChecker(object):
         with test_case.assertRaises(SyntaxError, msg=(text, ast.dump(node))):
           test_case.parse_snippet(text, node)
 
-  # Node types that check_get_text_unmarked should ignore.
-  bad_unmarked_types = (
-    # get_text_unmarked does something sensible for modules, but it differs from get_text.
-    ast.Module,
-    # no lineno
-    ast.arguments, ast.withitem,
-  )  # type: Tuple[Type[ast.AST], ...]
-  if sys.version_info[:2] == (3, 8):
-    bad_unmarked_types += (
-      # get_text_unmarked works incorrectly for these types due to bugs in Python 3.8.
-      ast.arg, ast.Starred,
-      # no lineno in 3.8
-      ast.Slice, ast.ExtSlice, ast.Index, ast.keyword,
+  # Node types that check_get_text_unmarked should ignore. Only relevant for Python 3.8+.
+  bad_unmarked_types = ()  # type: Tuple[Type[ast.AST], ...]
+  if sys.version_info[:2] >= (3, 8):
+    bad_unmarked_types = (
+      # get_text_unmarked does something sensible for modules, but it differs from get_text.
+      ast.Module,
+      # no lineno
+      ast.arguments, ast.withitem,
     )
+    if sys.version_info[:2] == (3, 8):
+      bad_unmarked_types += (
+        # get_text_unmarked works incorrectly for these types due to bugs in Python 3.8.
+        ast.arg, ast.Starred,
+        # no lineno in 3.8
+        ast.Slice, ast.ExtSlice, ast.Index, ast.keyword,
+      )
 
   def _check_alias_unmarked(self, node, test_case, text_unmarked):
     if sys.version_info < (3, 10):

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -120,8 +120,12 @@ class MarkChecker(object):
     as get_text_unmarked.
     """
 
-    if test_case.is_astroid_test or sys.version_info < (3, 8):
-      # astroid doesn't support get_text_unmarked, and before 3.8, ast doesn't either.
+    if (
+        test_case.is_astroid_test
+        or sys.version_info < (3, 8)
+        or 'pypy' in sys.version.lower()
+    ):
+      # These cases are not supported by get_text_unmarked
       return
 
     text_unmarked = self.atok.get_text_unmarked(node)


### PR DESCRIPTION
As mentioned in https://github.com/ipython/ipython/issues/13731#issuecomment-1227272665, although I think keeping the functionality here is still best, even if tokens aren't usually used.

For now I've just added two methods to `ASTTokens` so that they can be tested and compared to the original methods. Here's a proposal for an actual API:

1. Add a boolean argument `mark` (or `mark_tokens`) to the `ASTTokens` constructor.
2. If `mark=False`, then don't call `self.mark_tokens`.
3. `mark=True` by default for backwards compatibility. Personally I've often used the `first_token` and `last_token` attributes added to AST nodes.
4. `mark=False` is ignored for Python versions older than 3.8. It's still allowed so that callers don't have to check the Python version themselves. Same for PyPy, which apparently doesn't have correct position info either, even in 3.8.
5. `mark=False` is an error for an astroid tree. Even if it's easy to get it to work, I'm personally not interested in maintaining that.
6. The usual `get_text` and `get_text_range` methods should automatically pick the correct implementation based on whether the nodes have been marked with tokens. Then code that only uses these methods only needs to add `mark=False` to the constructor.
7. For cases where the unmarked implementation has known bugs, use the original implementation, calling `mark_tokens` first if necessary. Currently, this means `arg` and `Starred` nodes for Python 3.8, i.e. there's no problem for 3.9+. Those node types only seem to fail under specific conditions which I think are known, but for safety we can just check the type.
8. Ideally this should just start working automatically on nodes inside f-strings. These currently don't work here (#6) but `ast.get_source_segment` does, so the new implementation should too, hopefully transparently.
9. Add new method(s) to replace using `node.first_token.start` and `node.last_token.end`, i.e. they should return (lineno, col_offset) pairs instead of string indices. These will usually be the same as the standard `ast` values but not always.