### PR TITLE
Explore a clearer lazy-parsing behaviour API

### DIFF
--- a/asttokens/__init__.py
+++ b/asttokens/__init__.py
@@ -19,6 +19,6 @@ transformations.
 """
 
 from .line_numbers import LineNumbers
-from .asttokens import ASTTokens, supports_unmarked
+from .asttokens import ASTText, ASTTokens, supports_unmarked
 
-__all__ = ['ASTTokens', 'LineNumbers', 'supports_unmarked']
+__all__ = ['ASTText', 'ASTTokens', 'LineNumbers', 'supports_unmarked']

--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -323,7 +323,6 @@ class ASTText(ASTTextBase, object):
     """
     Unmarked version of ``get_text_positions()``.
 
-    Raises an error for unsupported Python versions, unlike ``init_tokens=False``.
     Raises an error for astroid tree.
     Doesn't raise an error for unsupported types of AST node, but may return incorrect results.
     """

--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -367,6 +367,8 @@ class ASTText(ASTTextBase, object):
     super(ASTText, self).__init__(source_text, filename)
 
     self._tree = tree
+    if self._tree is not None:
+      annotate_fstring_nodes(self._tree)
 
     self._asttokens = None  # type: Optional[ASTTokens]
 
@@ -375,6 +377,7 @@ class ASTText(ASTTextBase, object):
     # type: () -> Module
     if self._tree is None:
       self._tree = ast.parse(self._text, self._filename)
+      annotate_fstring_nodes(self._tree)
     return self._tree
 
   @property
@@ -402,6 +405,9 @@ class ASTText(ASTTextBase, object):
     Use ``unmarked=True`` to force the method to not use token information,
     however this will be preferred anyway for nodes where it is supported.
     """
+    if getattr(node, "_broken_positions", None):
+      return (1, 0), (1, 0)
+
     if unmarked or supports_unmarked(node):
       return self._get_text_positions_unmarked(node, padded)
 

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -31,7 +31,7 @@ class TestMarkTokens(unittest.TestCase):
 
   def create_mark_checker(self, source, verify=True):
     atok = self.create_asttokens(source)
-    checker = tools.MarkChecker(atok)
+    checker = tools.MarkChecker(atok, self.is_astroid_test)
 
     # The last token should always be an ENDMARKER
     # None of the nodes should contain that token
@@ -447,7 +447,7 @@ bar = ('x y z'   # comment2
       source = textwrap.dedent("""
         def foo(*, name: str):  # keyword-only argument with type annotation
           pass
-        
+
         f(*(x))  # ast.Starred with parentheses
       """)
       self.create_mark_checker(source)

--- a/tests/test_unmarked.py
+++ b/tests/test_unmarked.py
@@ -124,22 +124,6 @@ class TestUmarked(unittest.TestCase):
     with self.assertRaises(NotImplementedError):
       ASTText(source, tree)
 
-    atok = ASTTokens(source, tree=tree)
-    with self.assertRaises(NotImplementedError):
-      atok.get_text(tree, unmarked=True)
-
-
-@unittest.skipIf(supports_unmarked(), "Python version *does* support unmarked nodes")
-class TestNotSupportingUnmarked(unittest.TestCase):
-  def test_unmarked_version_error(self):
-    atok = ASTTokens('foo', parse=True)
-    with self.assertRaises(NotImplementedError):
-      atok.get_text(atok.tree, unmarked=True)
-
-    atext = ASTText('foo')
-    with self.assertRaises(NotImplementedError):
-      atext.get_text(atext.tree, unmarked=True)
-
 
 class TestFstringPositionsWork(unittest.TestCase):
   def test_fstring_positions_work(self):

--- a/tests/test_unmarked.py
+++ b/tests/test_unmarked.py
@@ -118,7 +118,7 @@ class TestUmarked(unittest.TestCase):
             ),
           )
 
-  def test_init_tokens_astroid_errors(self):
+  def test_lazy_asttext_astroid_errors(self):
     builder = astroid.builder.AstroidBuilder()
     tree = builder.string_build(source)
     with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This introduces a new class which has the lazy-parsing behaviour, separate from `ASTTokens`, thus leaving `ASTTokens` semantics unchanged.

`ASTTokens` still learns how to handle nodes unmarked, however it is left somewhat cautious in the use of them. The new class instead prefers them wherever it can.

This aims to provide an alternative to the API from #93 as the current API would make static analysis of `ASTTokens` much less useful when the `init_tokens` argument is used.

While it looks like there's a lot of change here, there isn't -- most of the diff is moving functions to the top of the file.