### PR TITLE
Fixes for newer astroid versions

### DIFF
--- a/asttokens/astroid_compat.py
+++ b/asttokens/astroid_compat.py
@@ -1,0 +1,14 @@
+try:
+  from astroid import nodes as astroid_node_classes
+
+  # astroid_node_classes should be whichever module has the NodeNG class
+  from astroid.nodes import NodeNG
+except Exception:
+  try:
+    from astroid import node_classes as astroid_node_classes
+    from astroid.node_classes import NodeNG
+  except Exception:
+    astroid_node_classes = None
+    NodeNG = None
+
+__all__ = ["astroid_node_classes", "NodeNG"]

--- a/asttokens/astroid_compat.py
+++ b/asttokens/astroid_compat.py
@@ -7,7 +7,7 @@ except Exception:
   try:
     from astroid import node_classes as astroid_node_classes
     from astroid.node_classes import NodeNG
-  except Exception:
+  except Exception:  # pragma: no cover
     astroid_node_classes = None
     NodeNG = None
 

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -23,13 +23,7 @@ import six
 
 from . import util
 from .asttokens import ASTTokens
-from .util import AstConstant
-
-try:
-  import astroid.node_classes as nc
-except Exception:
-  # This is only used for type checking, we don't need it if astroid isn't installed.
-  nc = None
+from .util import AstConstant, astroid_node_classes as nc
 
 if TYPE_CHECKING:
   from .util import AstNode
@@ -88,7 +82,8 @@ class MarkTokens(object):
     first = token
     last = None
     for child in cast(Callable, self._iter_children)(node):
-      if not first or child.first_token.index < first.index:
+      # astroid slices have especially wrong positions, we don't want them to corrupt their parents.
+      if not first or child.first_token.index < first.index and not util.is_astroid_slice(child):
         first = child.first_token
       if not last or child.last_token.index > last.index:
         last = child.last_token

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -83,7 +83,9 @@ class MarkTokens(object):
     last = None
     for child in cast(Callable, self._iter_children)(node):
       # astroid slices have especially wrong positions, we don't want them to corrupt their parents.
-      if not first or child.first_token.index < first.index and not util.is_astroid_slice(child):
+      if util.is_empty_astroid_slice(child):
+        continue
+      if not first or child.first_token.index < first.index:
         first = child.first_token
       if not last or child.last_token.index > last.index:
         last = child.last_token

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -23,7 +23,8 @@ import six
 
 from . import util
 from .asttokens import ASTTokens
-from .util import AstConstant, astroid_node_classes as nc
+from .util import AstConstant
+from .astroid_compat import astroid_node_classes as nc
 
 if TYPE_CHECKING:
   from .util import AstNode

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -24,8 +24,18 @@ from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Un
 
 from six import iteritems
 
+try:
+  from astroid import nodes as astroid_node_classes
+  getattr(astroid_node_classes, "NodeNG")
+except Exception:
+  try:
+    from astroid import node_classes as astroid_node_classes
+  except Exception:
+    astroid_node_classes = None
+
+
 if TYPE_CHECKING:  # pragma: no cover
-  from astroid.node_classes import NodeNG
+  NodeNG = astroid_node_classes.NodeNG
 
   # Type class used to expand out the definition of AST to include fields added by this library
   # It's not actually used for anything other than type checking though!
@@ -216,6 +226,11 @@ def is_slice(node):
           and any(map(is_slice, cast(ast.Tuple, node).elts))
       )
   )
+
+
+def is_astroid_slice(node):
+  # type: (AstNode) -> bool
+  return is_slice(node) and not isinstance(node, ast.AST)
 
 
 # Sentinel value used by visit_tree().

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -24,20 +24,10 @@ from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Un
 
 from six import iteritems
 
-try:
-  from astroid import nodes as astroid_node_classes
-  # astroid_node_classes should be whichever module has the NodeNG class
-  getattr(astroid_node_classes, "NodeNG")
-except Exception:
-  try:
-    from astroid import node_classes as astroid_node_classes
-  except Exception:
-    astroid_node_classes = None
+from .astroid_compat import NodeNG
 
 
 if TYPE_CHECKING:  # pragma: no cover
-  NodeNG = astroid_node_classes.NodeNG
-
   # Type class used to expand out the definition of AST to include fields added by this library
   # It's not actually used for anything other than type checking though!
   class EnhancedAST(AST):

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -26,6 +26,7 @@ from six import iteritems
 
 try:
   from astroid import nodes as astroid_node_classes
+  # astroid_node_classes should be whichever module has the NodeNG class
   getattr(astroid_node_classes, "NodeNG")
 except Exception:
   try:

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -224,7 +224,7 @@ def is_empty_astroid_slice(node):
   return (
       node.__class__.__name__ == "Slice"
       and not isinstance(node, ast.AST)
-      and node.lower is node.upper is node.step
+      and node.lower is node.upper is node.step is None
   )
 
 

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -228,9 +228,13 @@ def is_slice(node):
   )
 
 
-def is_astroid_slice(node):
+def is_empty_astroid_slice(node):
   # type: (AstNode) -> bool
-  return is_slice(node) and not isinstance(node, ast.AST)
+  return (
+      node.__class__.__name__ == "Slice"
+      and not isinstance(node, ast.AST)
+      and node.lower is node.upper is node.step
+  )
 
 
 # Sentinel value used by visit_tree().

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -24,10 +24,10 @@ from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Un
 
 from six import iteritems
 
-from .astroid_compat import NodeNG
-
 
 if TYPE_CHECKING:  # pragma: no cover
+  from .astroid_compat import NodeNG
+
   # Type class used to expand out the definition of AST to include fields added by this library
   # It's not actually used for anything other than type checking though!
   class EnhancedAST(AST):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ disallow_untyped_calls=false
 ignore_missing_imports=true
 
 [[tool.mypy.overrides]]
-module = ["astroid", "astroid.node_classes"]
+module = ["astroid", "astroid.node_classes", "astroid.nodes", "astroid.nodes.utils"]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 
 [options.extras_require]
-test = astroid<=2.5.3; pytest
+test = astroid; pytest
 
 [options.package_data]
 asttokens = py.typed

--- a/tests/test_astroid.py
+++ b/tests/test_astroid.py
@@ -2,9 +2,9 @@
 from __future__ import unicode_literals, print_function
 
 import astroid
-from astroid.node_classes import NodeNG
 
 from asttokens import ASTTokens
+from asttokens.util import astroid_node_classes
 from . import test_mark_tokens
 
 
@@ -13,7 +13,7 @@ class TestAstroid(test_mark_tokens.TestMarkTokens):
   is_astroid_test = True
   module = astroid
 
-  nodes_classes = NodeNG
+  nodes_classes = astroid_node_classes.NodeNG
   context_classes = [
     (astroid.Name, astroid.DelName, astroid.AssignName),
     (astroid.Attribute, astroid.DelAttr, astroid.AssignAttr),

--- a/tests/test_astroid.py
+++ b/tests/test_astroid.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, print_function
 import astroid
 
 from asttokens import ASTTokens
-from asttokens.util import astroid_node_classes
+from asttokens.astroid_compat import astroid_node_classes
 from . import test_mark_tokens
 
 

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -19,6 +19,11 @@ from asttokens import util, ASTTokens
 
 from . import tools
 
+try:
+  from astroid.nodes.utils import Position as AstroidPosition
+except Exception:
+  AstroidPosition = ()
+
 
 class TestMarkTokens(unittest.TestCase):
   maxDiff = None
@@ -243,7 +248,7 @@ b +     # line3
     # important, so we skip them here.
     self.assertEqual({n for n in m.view_nodes_at(1, 56) if 'Slice:' not in n},
                      { "Subscript:foo[:]", "Name:foo" })
-    self.assertEqual({n for n in m.view_nodes_at(1, 64) if 'Slice:' not in n},
+    self.assertEqual({n for n in m.view_nodes_at(1, 64) if 'Slice:' not in n and 'Tuple:' not in n},
                      { "Subscript:bar[::2, :]", "Name:bar" })
 
   def test_adjacent_strings(self):
@@ -813,6 +818,10 @@ partial_sums = [total := total + v for v in values]
         break
     else:
       self.assertEqual(type(t1), type(t2))
+
+    if isinstance(t1, AstroidPosition):
+      # Ignore the lineno/col_offset etc. from astroid
+      return
 
     if isinstance(t1, (list, tuple)):
       self.assertEqual(len(t1), len(t2))

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -235,7 +235,7 @@ b +     # line3
 
   def test_slices(self):
     # Make sure we don't fail on parsing slices of the form `foo[4:]`.
-    source = "(foo.Area_Code, str(foo.Phone)[:3], str(foo.Phone)[3:], foo[:], bar[::2, :], [a[:]][::-1])"
+    source = "(foo.Area_Code, str(foo.Phone)[:3], str(foo.Phone)[3:], foo[:], bar[::2, :], bar2[:, ::2], [a[:]][::-1])"
     m = self.create_mark_checker(source)
     self.assertIn("Tuple:" + source, m.view_nodes_at(1, 0))
     self.assertEqual(m.view_nodes_at(1, 1),


### PR DESCRIPTION
Fixes #70 and #79

- Removes astroid version constraint from tests, to test the latest astroid version for that Python version
- Handles classes moving from `astroid.node_classes` to `astroid.nodes`.
- When marking tokens, ignores empty astroid slices which mess up the positions of their parent nodes..
- Ignores incorrect tuple of astroid slices in `test_slices`.
- Ignores `Position` when asserting equal astroid nodes.