### PR TITLE
Account for a bug in multiline f-strings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/asttokens/asttokens.py
+++ b/asttokens/asttokens.py
@@ -58,7 +58,7 @@ class ASTTextBase(six.with_metaclass(abc.ABCMeta, object)):
     This means that if ``padded`` is True, the start position will be adjusted to include
     leading whitespace if ``node`` is a multiline statement.
     """
-    raise NotImplementedError
+    raise NotImplementedError  # pragma: no cover
 
   def get_text_range(self, node, padded=True):
     # type: (AstNode, bool) -> Tuple[int, int]
@@ -336,7 +336,8 @@ class ASTText(ASTTextBase, object):
     """
     Version of ``get_text_positions()`` that doesn't use tokens.
     """
-    if sys.version_info[:2] < (3, 8):
+    if sys.version_info[:2] < (3, 8):  # pragma: no cover
+      # This is just for mpypy
       raise AssertionError("This method should only be called internally after checking supports_tokenless()")
 
     if isinstance(node, ast.Module):

--- a/asttokens/util.py
+++ b/asttokens/util.py
@@ -418,12 +418,17 @@ if sys.version_info[:2] >= (3, 8):
     Specifically this checks:
      - Values with a format spec or conversion
      - Repeated (i.e. identical-looking) expressions
-     - Multiline f-strings implicitly concatenated.
+     - f-strings implicitly concatenated over multiple lines.
+     - Multiline, triple-quoted f-strings.
     """
     source = """(
       f"a {b}{b} c {d!r} e {f:g} h {i:{j}} k {l:{m:n}}"
       f"a {b}{b} c {d!r} e {f:g} h {i:{j}} k {l:{m:n}}"
       f"{x + y + z} {x} {y} {z} {z} {z!a} {z:z}"
+      f'''
+      {s} {t}
+      {u} {v}
+      '''
     )"""
     tree = ast.parse(source)
     name_nodes = [node for node in ast.walk(tree) if isinstance(node, ast.Name)]

--- a/tests/test_tokenless.py
+++ b/tests/test_tokenless.py
@@ -125,5 +125,5 @@ class TestFstringPositionsWork(unittest.TestCase):
   def test_fstring_positions_work(self):
     self.assertEqual(
       fstring_positions_work() and supports_tokenless(),
-      sys.version_info >= (3, 9, 7),
+      sys.version_info >= (3, 10, 6),
     )


### PR DESCRIPTION
I discovered *another* f-string positions bug. It was fixed in https://github.com/python/cpython/issues/94869 and released in 3.10.6 according to https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-6-final.

Theoretically, you could maybe check if the specific f-string is multiline to continue supporting non-multiline strings between 3.9.7 and 3.10.6.