### PR TITLE
Pinned minimum version of the six package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ classifiers =
 [options]
 packages = asttokens
 install_requires = 
-    six
+    six >= 1.12.0
     typing; python_version < "3.5"
 setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 


### PR DESCRIPTION
I have stumbled upon this issue, when migrating to python 3.11 in my project. I had `six==1.11.0` pinned in our requirements and since `asttokens` setup config does not specify minimum six version, that seemed to be OK. It is a good practice to always pin at least minimum needed version, when using some functions introduced in newer ones.

I have pinned the version `>= 1.12.0` because [this is the first one to introduce](https://github.com/benjaminp/six/commit/db3d0d678b422614d5de0f9ed76a2112a28c7b19#diff-f1210676bc966206a8582af61676229cf9eb7a5df5acb4c0a87663b08c7fda4dR890-R906) `ensure_text` function, that is being used in `executing` package. In my case the issue came from ipython (newest version) that is using `asttokens` deeper in its dependencies.