### PR TITLE
Add readthedocs configuration file, and fix GHA for Python 2.7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
       COVERALLS_PARALLEL: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -74,7 +74,7 @@ jobs:
       COVERALLS_PARALLEL: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -98,7 +98,7 @@ jobs:
   mypy-py2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - 2.7
           - 3.5
           - 3.6
           - 3.7
@@ -32,9 +33,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.python-version != '2.7'
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Set up Python 2.7
+        if: matrix.python-version == '2.7'
+        run: |
+          sudo apt-get update
+          sudo apt-get install python2.7 -y
 
       - name: Install dependencies
         run: |
@@ -62,37 +70,6 @@ jobs:
         run: |
           pip3 install --upgrade coveralls
           python3 -m coveralls --service=github
-
-  test-py2:
-    # Python 2.7 is no longer available directly with actions/setup-python, but it is when
-    # using a container. See https://github.com/actions/setup-python/issues/672#issuecomment-1589120020.
-    runs-on: ubuntu-20.04
-    container:
-      image: python:2.7.18-buster
-    env:
-      ASTTOKENS_SLOW_TESTS: 1
-      COVERALLS_PARALLEL: true
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade coveralls pytest setuptools setuptools_scm pep517
-          pip install .[test]
-
-      - name: Test with pytest
-        run: |
-          coverage run --branch --include='asttokens/*' -m pytest --junitxml=./rspec.xml
-          coverage report -m
-
-      ## Coveralls don't work out of the box in this Python 2.7 container.
-      #- name: Collect coverage results
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #  run: |
-      #    pip3 install --upgrade coveralls
-      #    python3 -m coveralls --service=github
 
   # Can't run mypy on Python 2.7, but can run it in Python 2 mode
   mypy-py2:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,8 +90,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip3 install --upgrade coveralls
-          python3 -m coveralls --service=github
+          python -m coveralls --service=github
 
   # Can't run mypy on Python 2.7, but can run it in Python 2 mode
   mypy-py2:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 2.7
           - 3.5
           - 3.6
           - 3.7
@@ -51,6 +50,41 @@ jobs:
         if: ${{ !contains(fromJson('["2.7", "pypy-2.7", "pypy-3.6", "pypy-3.7"]'), matrix.python-version) }}
         # pypy < 3.8 very doesn't work
         # 2.7 is tested separately in mypy-py2, as we need to run mypy under Python 3.x
+
+      - name: Test with pytest
+        run: |
+          coverage run --branch --include='asttokens/*' -m pytest --junitxml=./rspec.xml
+          coverage report -m
+
+      - name: Collect coverage results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip3 install --upgrade coveralls
+          python3 -m coveralls --service=github
+
+  test-py2:
+    # Python 2.7 is no longer available directly with actions/setup-python@v2, but it is when
+    # using a container. See https://github.com/actions/setup-python/issues/672#issuecomment-1589120020.
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
+    env:
+      ASTTOKENS_SLOW_TESTS: 1
+      COVERALLS_PARALLEL: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade coveralls pytest setuptools setuptools_scm pep517
+          pip install .[test]
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -64,7 +64,7 @@ jobs:
           python3 -m coveralls --service=github
 
   test-py2:
-    # Python 2.7 is no longer available directly with actions/setup-python@v2, but it is when
+    # Python 2.7 is no longer available directly with actions/setup-python, but it is when
     # using a container. See https://github.com/actions/setup-python/issues/672#issuecomment-1589120020.
     runs-on: ubuntu-20.04
     container:
@@ -75,11 +75,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Set up Python 2.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
 
       - name: Install dependencies
         run: |
@@ -105,7 +100,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,11 +86,13 @@ jobs:
           coverage run --branch --include='asttokens/*' -m pytest --junitxml=./rspec.xml
           coverage report -m
 
-      - name: Collect coverage results
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python -m coveralls --service=github
+      ## Coveralls don't work out of the box in this Python 2.7 container.
+      #- name: Collect coverage results
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #  run: |
+      #    pip3 install --upgrade coveralls
+      #    python3 -m coveralls --service=github
 
   # Can't run mypy on Python 2.7, but can run it in Python 2 mode
   mypy-py2:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt


### PR DESCRIPTION
Adds a minimal readthedocs configuration file, to keep https://asttokens.readthedocs.io/en/readthedocs/ active. See https://blog.readthedocs.com/migrate-configuration-v2/.

Also, GitHub Actions has dropped support for Python 2.7 in its built-in actions (see https://github.com/actions/setup-python/issues/672). Add a workaround to keep testing it.