### PR TITLE
Make github actions use Python2 for tests that ask for it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install python2.7 -y
+          # Get everything to use this new Python as the default.
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          sudo python2.7 get-pip.py
+          sudo mv /usr/bin/pip /usr/bin/pip_backup
+          sudo ln -s /usr/bin/pip2 /usr/bin/pip
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 2
+          sudo update-alternatives --config python
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,11 +46,8 @@ jobs:
           # Get everything to use this new Python as the default.
           curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
           sudo python2.7 get-pip.py
-          sudo mv /usr/bin/pip /usr/bin/pip_backup
-          sudo ln -s /usr/bin/pip2 /usr/bin/pip
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 2
-          sudo update-alternatives --config python
+          sudo ln -sf /usr/bin/pip2 /usr/bin/pip
+          sudo ln -sf /usr/bin/python2.7 /usr/bin/python
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The previous change to github actions (in #112) didn't actually make the Python 2.7 test use Python 2.7. This corrects it.