### PR TITLE
Cope with Astroid having renamed _BaseContainer

### DIFF
--- a/asttokens/astroid_compat.py
+++ b/asttokens/astroid_compat.py
@@ -11,4 +11,11 @@ except Exception:
     astroid_node_classes = None
     NodeNG = None
 
-__all__ = ["astroid_node_classes", "NodeNG"]
+BaseContainer = getattr(
+  astroid_node_classes,
+  'BaseContainer',
+  getattr(astroid_node_classes, '_BaseContainer', None),
+)
+
+
+__all__ = ["astroid_node_classes", "NodeNG", "BaseContainer"]

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -24,7 +24,7 @@ import six
 from . import util
 from .asttokens import ASTTokens
 from .util import AstConstant
-from .astroid_compat import astroid_node_classes as nc
+from .astroid_compat import astroid_node_classes as nc, BaseContainer as AstroidBaseContainer
 
 if TYPE_CHECKING:
   from .util import AstNode
@@ -312,7 +312,7 @@ class MarkTokens(object):
     # In Python3.8 parsed tuples include parentheses when present.
     def handle_tuple_nonempty(self, node, first_token, last_token):
       # type: (AstNode, util.Token, util.Token) -> Tuple[util.Token, util.Token]
-      assert isinstance(node, ast.Tuple) or isinstance(node, nc._BaseContainer)
+      assert isinstance(node, ast.Tuple) or isinstance(node, AstroidBaseContainer)
       # It's a bare tuple if the first token belongs to the first child. The first child may
       # include extraneous parentheses (which don't create new nodes), so account for those too.
       child = node.elts[0]
@@ -331,7 +331,7 @@ class MarkTokens(object):
 
   def visit_tuple(self, node, first_token, last_token):
     # type: (AstNode, util.Token, util.Token) -> Tuple[util.Token, util.Token]
-    assert isinstance(node, ast.Tuple) or isinstance(node, nc._BaseContainer)
+    assert isinstance(node, ast.Tuple) or isinstance(node, AstroidBaseContainer)
     if not node.elts:
       # An empty tuple is just "()", and we need no further info.
       return (first_token, last_token)


### PR DESCRIPTION
Fix per https://github.com/gristlabs/asttokens/issues/100#issuecomment-1766877629, I haven't checked the release notes myself.

This leaves three remaining test failures which originate from astroid v3.