### PR TITLE
Use pytest-xdist to speed up CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+include = asttokens/*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run --branch --include='asttokens/*' -m pytest --junitxml=./rspec.xml
+          coverage run --branch --include='asttokens/*' -m pytest -n auto --junitxml=./rspec.xml
           coverage report -m
 
       - name: Collect coverage results

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run --branch --include='asttokens/*' -m pytest -n auto --junitxml=./rspec.xml
+          pytest --cov -n auto --junitxml=./rspec.xml
           coverage report -m
 
       - name: Collect coverage results

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ test =
     astroid >=1, <2; python_version < "3"
     astroid >=2, <4; python_version >= "3"
     pytest
+    pytest-cov
     pytest-xdist
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ test =
     astroid >=1, <2; python_version < "3"
     astroid >=2, <4; python_version >= "3"
     pytest
+    pytest-xdist
 
 [options.package_data]
 asttokens = py.typed


### PR DESCRIPTION
Contributes towards #129.
This reduces the CI time from ~30 minutes to ~20 minutes.