### PR TITLE
Run slow tests without coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+include = asttokens/*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,10 +81,16 @@ jobs:
         # pypy < 3.8 very doesn't work
         # 2.7 is tested separately in mypy-py2, as we need to run mypy under Python 3.x
 
-      - name: Test with pytest
+      - name: Fast tests with coverage
         run: |
-          pytest --cov -n auto --junitxml=./rspec.xml
+          pytest --cov -n auto -m "not slow"
           coverage report -m
+
+      - name: Slow tests without coverage
+        # Python 2.7 doesn't have any slow tests
+        if: ${{ !contains(fromJson('["2.7", "pypy-2.7"]'), matrix.python-version) }}
+        run: |
+          pytest -n auto -m slow
 
       - name: Collect coverage results
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run --branch --include='asttokens/*' -m pytest --junitxml=./rspec.xml
+          coverage run --branch --include='asttokens/*' -m pytest -n auto --junitxml=./rspec.xml
           coverage report -m
 
       - name: Collect coverage results

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run --branch --include='asttokens/*' -m pytest -n auto --junitxml=./rspec.xml
+          pytest --cov -n auto --junitxml=./rspec.xml
           coverage report -m
 
       - name: Collect coverage results

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,6 @@ jobs:
             astroid-version: '<3'
 
     env:
-      ASTTOKENS_SLOW_TESTS: 1
       COVERALLS_PARALLEL: true
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -79,4 +79,5 @@ To contribute:
 
 3. Run tests in your current interpreter with the command ``pytest`` or ``python -m pytest``.
 4. Run tests across all supported interpreters with the ``tox`` command. You will need to have the interpreters installed separately. We recommend ``pyenv`` for that. Use ``tox -p auto`` to run the tests in parallel.
-5. By default certain tests which take a very long time to run are skipped, but they are run on travis CI. To run them locally, set the environment variable ``ASTTOKENS_SLOW_TESTS``. For example run ``ASTTOKENS_SLOW_TESTS=1 tox`` to run the full suite of tests.
+5. By default certain tests which take a very long time to run are skipped, but they are run in CI.
+   These are marked using the ``pytest`` marker ``slow`` and can be run on their own with ``pytest -m slow`` or as part of the full suite with ``pytest -m ''``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ test =
     astroid >=1, <2; python_version < "3"
     astroid >=2, <4; python_version >= "3"
     pytest
+    pytest-cov
     pytest-xdist
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,4 +61,6 @@ universal=1
 
 
 [tool:pytest]
-addopts = --disable-warnings --ignore=tests/testdata
+addopts = --disable-warnings --ignore=tests/testdata --strict-markers
+markers =
+  slow: marks tests as slow (deselect with '-m "not slow"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ test =
     astroid >=1, <2; python_version < "3"
     astroid >=2, <4; python_version >= "3"
     pytest
+    pytest-xdist
 
 [options.package_data]
 asttokens = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,6 @@ universal=1
 
 
 [tool:pytest]
-addopts = --disable-warnings --ignore=tests/testdata --strict-markers
+addopts = --disable-warnings --ignore=tests/testdata --strict-markers -m 'not slow'
 markers =
-  slow: marks tests as slow (deselect with '-m "not slow"')
+  slow: marks tests as slow (deselected by default)

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -5,6 +5,7 @@ import ast
 import inspect
 import io
 import os
+import pytest
 import re
 import sys
 import textwrap
@@ -630,6 +631,7 @@ j  # not a complex number, just a name
     self.create_mark_checker(source)
 
   if six.PY3:
+    @pytest.mark.slow
     def test_sys_modules(self):
       """
       Verify all nodes on source files obtained from sys.modules.

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -635,15 +635,14 @@ j  # not a complex number, just a name
     def test_sys_modules(self):
       """
       Verify all nodes on source files obtained from sys.modules.
+
       This can take a long time as there are many modules,
-      so it only tests all modules if the environment variable
-      ASTTOKENS_SLOW_TESTS has been set.
+      so is marked as a slow test and must be explicitly selected
+      for running.
       """
       from .test_astroid import AstroidTreeException
 
       modules = list(sys.modules.values())
-      if not os.environ.get('ASTTOKENS_SLOW_TESTS'):
-        modules = modules[:20]
 
       start = time()
       for module in modules:

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,3 @@ envlist = py{27,35,36,37,38,39,310,311,py,py3}
 commands = pytest {posargs}
 deps =
     .[test]
-passenv =
-    ASTTOKENS_SLOW_TESTS


### PR DESCRIPTION
Per suggestion from @alexmojaki at https://github.com/gristlabs/asttokens/issues/129#issuecomment-1779132057

These slower tests are integration/kitchen-sink tests, so they shouldn't add substantially to the code coverage. Running them without coverage is quite a lot faster (several minutes in CI) which is well worth the small additional complexity.

This commit also drops pytest outputting the junit xml file as there's not an obvious way to combine that from multiple test runs and it appears to be unused.

This reduces the CI time from ~20 minutes to ~10 minutes, however there's a small reduction in _measured_ coverage. Happy to address that here with unit tests if desired.

Builds on #128.
Fixes #129 as CI time is no longer quite as silly.