### PR TITLE
Replace ast.Str usages with ast.Constant for compatibility with Python 3.14

### DIFF
--- a/tests/test_asttokens.py
+++ b/tests/test_asttokens.py
@@ -125,7 +125,7 @@ class TestASTTokens(unittest.TestCase):
 
     # Verify that ast parser produces offsets as we expect. This is just to inform the
     # implementation.
-    string_node = next(n for n in ast.walk(root) if isinstance(n, ast.Str))
+    string_node = next(n for n in ast.walk(root) if isinstance(n, ast.Constant))
     self.assertEqual(string_node.lineno, 1)
     self.assertEqual(string_node.col_offset, 4)
 

--- a/tests/test_tokenless.py
+++ b/tests/test_tokenless.py
@@ -47,7 +47,7 @@ def is_fstring_format_spec(node):
       and len(node.values) == 1
       and (
           (
-              isinstance(node.values[0], ast.Str)
+              isinstance(node.values[0], ast.Constant)
               and node.values[0].value in ['.2f']
           ) or (
               isinstance(node.values[0], ast.FormattedValue)
@@ -97,7 +97,7 @@ class TestTokenless(unittest.TestCase):
       atok_text = atok.get_text(node, padded=padded)
       if ast_text:
         if sys.version_info < (3, 12) and (
-          ast_text.startswith("f") and isinstance(node, (ast.Str, ast.FormattedValue))
+          ast_text.startswith("f") and isinstance(node, (ast.Constant, ast.FormattedValue))
           or is_fstring_format_spec(node)
           or (not fstring_positions_work() and is_fstring_internal_node(node))
         ):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -98,7 +98,7 @@ class TestUtil(unittest.TestCase):
     source = "foo(bar(1 + 2), 'hello' + ', ' + 'world')"
     atok = asttokens.ASTTokens(source, parse=True)
     names = [n for n in asttokens.util.walk(atok.tree) if isinstance(n, ast.Name)]
-    strings = [n for n in asttokens.util.walk(atok.tree) if isinstance(n, ast.Str)]
+    strings = [n for n in asttokens.util.walk(atok.tree) if isinstance(n, ast.Constant) and isinstance(n.value, str)]
     repl1 = [atok.get_text_range(n) + ('TEST',) for n in names]
     repl2 = [atok.get_text_range(n) + ('val',) for n in strings]
     self.assertEqual(asttokens.util.replace(source, repl1 + repl2),


### PR DESCRIPTION
Per What's new in Python 3.14:
ast.Str has been deprecated since Python 3.8, and have emitted deprecation warnings since Python 3.12.
https://docs.python.org/dev/whatsnew/3.14.html#id3

Spotted in Fedora Linux while early integrating 3.14 alphas into the distribution. 
I only saw failures in test_util.py, test_asstokens.py; test_tokenless passed successfully in our environment (we've got asttokens 2.4.1). I'm not sure why is that - whether the particular code path is never executed, but I made the change everywhere nevertheless.