### PR TITLE
Extend token ranges onto trailing capture names in match patterns and PEP 695 type params

### DIFF
--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -262,12 +262,15 @@ class MarkTokens:
   # the name. astroid stores the same names as AssignName children, hence the isinstance checks.
 
   def _extend_to_name(self, name: object, last_token: util.Token) -> util.Token:
-    """Extend last_token onto an immediately following NAME token equal to `name`."""
-    if not isinstance(name, str):
-      return last_token
-    following = self._code.next_token(last_token)
-    if util.match_token(following, token.NAME, name):
-      return following
+    """Extend last_token onto an immediately following NAME token equal to `name`.
+
+    `name` is only a string for `ast`; astroid stores the same captures as AssignName
+    children, and those already carry a position, so there is nothing to extend onto.
+    """
+    if isinstance(name, str):
+      following = self._code.next_token(last_token)
+      if util.match_token(following, token.NAME, name):
+        return following
     return last_token
 
   def visit_matchstar(

--- a/asttokens/mark_tokens.py
+++ b/asttokens/mark_tokens.py
@@ -257,6 +257,58 @@ class MarkTokens:
     last_token = self.handle_following_brackets(node, last_token, '(')
     return (first_token, last_token)
 
+  # `ast` stores the trailing name of these nodes as a plain identifier rather than as a child
+  # node, so there is no child for last_token to extend to and it stops on the operator before
+  # the name. astroid stores the same names as AssignName children, hence the isinstance checks.
+
+  def _extend_to_name(self, name: object, last_token: util.Token) -> util.Token:
+    """Extend last_token onto an immediately following NAME token equal to `name`."""
+    if not isinstance(name, str):
+      return last_token
+    following = self._code.next_token(last_token)
+    if util.match_token(following, token.NAME, name):
+      return following
+    return last_token
+
+  def visit_matchstar(
+    self, node: AstNode, first_token: util.Token, last_token: util.Token
+  ) -> Tuple[util.Token, util.Token]:
+    # 'case [*rest]', and 'case [*_]' where name is None but '_' is still written.
+    name = getattr(node, 'name', None)
+    return (first_token, self._extend_to_name('_' if name is None else name, last_token))
+
+  def visit_typevartuple(
+    self, node: AstNode, first_token: util.Token, last_token: util.Token
+  ) -> Tuple[util.Token, util.Token]:
+    # PEP 695 '*Ts' and '**P'.
+    return (first_token, self._extend_to_name(getattr(node, 'name', None), last_token))
+
+  visit_paramspec = visit_typevartuple
+
+  def visit_matchas(
+    self, node: AstNode, first_token: util.Token, last_token: util.Token
+  ) -> Tuple[util.Token, util.Token]:
+    # 'case str() as s'. Without a sub-pattern ('case s') first_token is already the name.
+    name = getattr(node, 'name', None)
+    if isinstance(name, str) and getattr(node, 'pattern', None) is not None:
+      as_token = self._code.next_token(last_token)
+      if util.match_token(as_token, token.NAME, 'as'):
+        last_token = self._extend_to_name(name, as_token)
+    return (first_token, last_token)
+
+  def visit_matchmapping(
+    self, node: AstNode, first_token: util.Token, last_token: util.Token
+  ) -> Tuple[util.Token, util.Token]:
+    # "case {'k': v, **rest}". The closing brace is picked up by the re-expansion afterwards.
+    rest = getattr(node, 'rest', None)
+    if isinstance(rest, str):
+      following = self._code.next_token(last_token)
+      if util.match_token(following, token.OP, ','):
+        following = self._code.next_token(following)
+      if util.match_token(following, token.OP, '**'):
+        last_token = self._extend_to_name(rest, following)
+    return (first_token, last_token)
+
   def visit_subscript(
     self,
     node: AstNode,

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -847,6 +847,41 @@ if 0:
         '          pass',
       })
 
+  if sys.version_info >= (3, 10):
+    def test_match_case_capture_names(self):
+      # The trailing capture name of MatchStar/MatchAs/MatchMapping is a plain identifier in
+      # `ast`, not a child node, so nothing extended the node's tokens onto it.
+      if self.is_astroid_test:
+        # astroid gives the AssignName for a capture the enclosing pattern's position,
+        # so these only get the correct tokens for ast, like slices above.
+        self.skipTest('astroid capture names have the pattern position')
+      m = self.create_mark_checker("""
+match cmd:
+  case [1, *rest]:
+    pass
+  case {'k': v, **extra}:
+    pass
+  case str() as s:
+    pass
+""")
+      seen = {(tools.get_node_name(n), m.atok.get_text(n)) for n in m.all_nodes}
+      self.assertIn(('MatchStar', '*rest'), seen)
+      self.assertIn(('MatchSequence', '[1, *rest]'), seen)
+      self.assertIn(('MatchMapping', "{'k': v, **extra}"), seen)
+      self.assertIn(('MatchAs', 'str() as s'), seen)
+
+  if sys.version_info >= (3, 12):
+    def test_pep695_type_params(self):
+      if self.is_astroid_test:
+        # As above: astroid's AssignName for '*Ts'/'**P' carries the whole type param's position.
+        self.skipTest('astroid type param names have the type param position')
+      m = self.create_mark_checker("def f[T, U: int, *Ts, **P](x): pass\n")
+      seen = {(tools.get_node_name(n), m.atok.get_text(n)) for n in m.all_nodes}
+      self.assertIn(('TypeVar', 'T'), seen)
+      self.assertIn(('TypeVar', 'U: int'), seen)
+      self.assertIn(('TypeVarTuple', '*Ts'), seen)
+      self.assertIn(('ParamSpec', '**P'), seen)
+
   def parse_snippet(self, text, node):
     """
     Returns the parsed AST tree for the given text, handling issues with indentation and newlines

--- a/tests/test_mark_tokens.py
+++ b/tests/test_mark_tokens.py
@@ -861,6 +861,10 @@ match cmd:
     pass
   case {'k': v, **extra}:
     pass
+  case {'j': w}:
+    pass
+  case {**only}:
+    pass
   case str() as s:
     pass
 """)
@@ -868,6 +872,8 @@ match cmd:
       self.assertIn(('MatchStar', '*rest'), seen)
       self.assertIn(('MatchSequence', '[1, *rest]'), seen)
       self.assertIn(('MatchMapping', "{'k': v, **extra}"), seen)
+      self.assertIn(('MatchMapping', "{'j': w}"), seen)
+      self.assertIn(('MatchMapping', '{**only}'), seen)
       self.assertIn(('MatchAs', 'str() as s'), seen)
 
   if sys.version_info >= (3, 12):


### PR DESCRIPTION
`MatchStar`, `MatchAs`, `MatchMapping`, `TypeVarTuple` and `ParamSpec` store their trailing capture name as a plain `identifier` string rather than as a child node ([ast docs](https://docs.python.org/3/library/ast.html#pattern-matching); ASDL: `MatchStar(identifier? name)`, `MatchAs(pattern? pattern, identifier? name)`, `MatchMapping(..., identifier? rest)`, `TypeVarTuple(identifier name, ...)`). `_visit_after_children` derives the range from child nodes, so there is nothing to extend onto and `last_token` stops on the operator before the name — the same gap `visit_starred` already fills for `ast.Starred`.

```python
>>> atok.get_text(matchstar)      # source: case [1, *rest]
'*'
>>> atok.get_text(matchsequence)
'[1, *'                           # not just short — not parsable
```
Also `case {'k': v, **extra}` → `{'k': v`, `case str() as s` → `str()`, and `*Ts` / `**P` → `*` / `**`.

**Measured against `ast.get_source_segment`** on CPython 3.14.7's own `test/test_patma.py` (1,083 pattern nodes): **135 mismatches → 6**, same file, same session. Across the rest of the stdlib (722 files, `test/` excluded, 263 pattern/type-param nodes): **1 → 0**.

**Residual, disclosed:** the remaining 6 are all open sequence patterns with a trailing comma (`case *x,:` → `*x`). `handle_bare_tuple` gives `ast.Tuple` that comma but there is no `MatchSequence` equivalent. I left it out because a bracketed `MatchSequence` nested in an open one needs the bracketed/unbracketed distinction `visit_tuple` makes, and I'd rather that were its own change. Say the word and I'll add it here.

**astroid is not fixed and the new tests skip it.** astroid gives the `AssignName` for a capture the *enclosing pattern's* position (`AssignName.rest` reports `col_offset` 11–16 for `[1, *rest]`), so `ASTTokens` returns `'[1, *'` there on unmodified master too — I verified that before touching anything. Same shape as the existing "slices currently only get the correct tokens/text for ast, not astroid" carve-out.

**Ran:** `pytest` 125 passed → 127 passed (+2 new, +2 astroid skips); `pytest -m slow` 2 passed; `mypy asttokens tests/*.py` clean. Two mutants, same command and env: reverting `mark_tokens.py` fails both new tests; a partial fix adding only `visit_matchstar` still fails both — so the test discriminates between remedies rather than just passing.

Found by diffing asttokens' per-node handler table against the `ast` grammar, then comparing `get_text` with `get_source_segment` node by node — not from hitting it in real work. #76 ("Test new syntax in 3.10") turned up afterwards; the probe suggested there, importing `test.test_patma`, is exactly the corpus that shows the 135.

_AI disclosure: prepared with assistance from Claude Opus 5 (`claude-opus-5`). Every command and number above I ran and read myself._
